### PR TITLE
make test output less verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ env:
 
 matrix:
   include:
-    #- python: 2.7
-    #  env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
     - python: 2.7
-    #- python: 3.5
-    #- python: 3.6
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
+    - python: 2.7
+    - python: 3.5
+    - python: 3.6
 
 before_install:
   - |
@@ -52,6 +52,7 @@ before_install:
     echo "[yt]" > $HOME/.config/yt/ytrc
     echo "suppressStreamLogging = True" >> $HOME/.config/yt/ytrc
     echo "test_data_dir = $YT_DATA" >> $HOME/.config/yt/ytrc
+    echo "loglevel = 30" >> $HOME/.config/yt/ytrc
     cat $HOME/.config/yt/ytrc
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     YT_DIR=$HOME/yt-git
     YT_DATA=$HOME/yt_test
     TEST_DIR=$HOME/test_results
-    TEST_FLAGS="--with-answer-testing --local --local-dir $TEST_DIR --answer-name=astro_analysis --answer-big-data"
+    TEST_FLAGS="--nologcapture -v --with-answer-testing --local --local-dir $TEST_DIR --answer-name=astro_analysis --answer-big-data"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
 matrix:
   include:
     - python: 2.7
-      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY=h5py SCIPY= FASTCACHE= IPYTHON=ipython==1.0
     - python: 2.7
     - python: 3.5
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,7 @@ setup(
         'cython>=0.24',
     ],
     install_requires=[
+        'h5py',
         'matplotlib',
         'setuptools>=19.6',
         'sympy',
@@ -182,7 +183,7 @@ setup(
     },
     cmdclass={'sdist': sdist, 'build_ext': build_ext, 'build_py': build_py},
     author="The yt project",
-    author_email="yt-dev@lists.spacepope.org",
+    author_email="yt-dev@python.org",
     url="http://yt-project.org/",
     license="BSD",
     zip_safe=False,


### PR DESCRIPTION
The log output from travis is so long as to make it difficult to find the errors. This sets the loglevel to warn to hopefully bring that down a bit.  I also uncommented the python 3 and minimum dependency python 2 tests because it looks like they get run anyway.