### PR TITLE
Make yt_astro_analysis pip installable

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,8 +1,9 @@
-To cite yt in publications, please use:
+To cite yt_astro_analysis in publications, please use:
 
 Turk, M. J., Smith, B. D., Oishi, J. S., et al. 2011, ApJS, 192, 9
 
-In the body of the text, please add a footnote to the yt webpage:
+In the body of the text, please refer to "the yt_astro_analysis
+extension of yt" and add a footnote to the yt webpage:
 
 http://yt-project.org/
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,5 @@
+Please contribute to the yt_astro_analysis package!
+
+This package is part of the yt project and we really want your help.
+For a guide to getting involved, see the yt developer guide at
+http://yt-project.org/doc/developing/.

--- a/CREDITS
+++ b/CREDITS
@@ -1,0 +1,3 @@
+yt_astro_analysis is a group effort by the yt community.
+
+Thanks to everyone for all your contributions!

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include README* CREDITS COPYING.txt CITATION  setupext.py CONTRIBUTING.rst
+recursive-include yt_astro_analysis *.py *.pyx *.pxd *.h README* *.txt LICENSE* *.cu
+recursive-include doc *.rst *.txt *.py *.ipynb *.png *.jpg *.css *.html
+recursive-include doc *.h *.c *.sh *.svgz *.pdf *.svg *.pyx
+include doc/extensions/README doc/Makefile
+prune doc/source/generated
+prune doc/build

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,1 @@
+git clean -f -d -x yt_astro_analysis

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ try:
 except pkg_resources.DistributionNotFound:
     pass  # yay!
 
-VERSION = "0.0.1"
+VERSION = "1.0.0.dev1"
 
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
@@ -149,11 +149,9 @@ setup(
     ],
     install_requires=[
         'h5py',
-        'matplotlib',
         'setuptools>=19.6',
         'sympy',
         'numpy',
-        'IPython',
         'cython',
         'yt>=3.3.5',
     ],

--- a/setup.py
+++ b/setup.py
@@ -89,27 +89,6 @@ if os.path.exists("rockstar.cfg"):
                              os.path.join(rd, "io"), os.path.join(rd, "util")]
     extensions += rockstar_extensions
 
-# class build_py(_build_py):
-#     def run(self):
-#         # honor the --dry-run flag
-#         if not self.dry_run:
-#             target_dir = os.path.join(self.build_lib, 'yt')
-#             src_dir = os.getcwd()
-#             changeset = get_mercurial_changeset_id(src_dir)
-#             self.mkpath(target_dir)
-#             with open(os.path.join(target_dir, '__hg_version__.py'), 'w') as fobj:
-#                 fobj.write("hg_version = '%s'\n" % changeset)
-#         _build_py.run(self)
-
-#     def get_outputs(self):
-#         # http://bitbucket.org/yt_analysis/yt/issues/1296
-#         outputs = _build_py.get_outputs(self)
-#         outputs.append(
-#             os.path.join(self.build_lib, 'yt', '__hg_version__.py')
-#         )
-#         return outputs
-
-
 class build_ext(_build_ext):
     # subclass setuptools extension builder to avoid importing cython and numpy
     # at top level in setup.py. See http://stackoverflow.com/a/21621689/1382869

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.command.sdist import sdist as _sdist
 from setuptools.command.build_py import build_py as _build_py
 from setupext import \
     check_for_openmp, check_for_pyembree, read_embree_location, \
-    get_mercurial_changeset_id, in_conda_env
+    in_conda_env
 from distutils.version import LooseVersion
 import pkg_resources
 
@@ -89,25 +89,25 @@ if os.path.exists("rockstar.cfg"):
                              os.path.join(rd, "io"), os.path.join(rd, "util")]
     extensions += rockstar_extensions
 
-class build_py(_build_py):
-    def run(self):
-        # honor the --dry-run flag
-        if not self.dry_run:
-            target_dir = os.path.join(self.build_lib, 'yt')
-            src_dir = os.getcwd()
-            changeset = get_mercurial_changeset_id(src_dir)
-            self.mkpath(target_dir)
-            with open(os.path.join(target_dir, '__hg_version__.py'), 'w') as fobj:
-                fobj.write("hg_version = '%s'\n" % changeset)
-        _build_py.run(self)
+# class build_py(_build_py):
+#     def run(self):
+#         # honor the --dry-run flag
+#         if not self.dry_run:
+#             target_dir = os.path.join(self.build_lib, 'yt')
+#             src_dir = os.getcwd()
+#             changeset = get_mercurial_changeset_id(src_dir)
+#             self.mkpath(target_dir)
+#             with open(os.path.join(target_dir, '__hg_version__.py'), 'w') as fobj:
+#                 fobj.write("hg_version = '%s'\n" % changeset)
+#         _build_py.run(self)
 
-    def get_outputs(self):
-        # http://bitbucket.org/yt_analysis/yt/issues/1296
-        outputs = _build_py.get_outputs(self)
-        outputs.append(
-            os.path.join(self.build_lib, 'yt', '__hg_version__.py')
-        )
-        return outputs
+#     def get_outputs(self):
+#         # http://bitbucket.org/yt_analysis/yt/issues/1296
+#         outputs = _build_py.get_outputs(self)
+#         outputs.append(
+#             os.path.join(self.build_lib, 'yt', '__hg_version__.py')
+#         )
+#         return outputs
 
 
 class build_ext(_build_ext):
@@ -181,7 +181,7 @@ setup(
     extras_require = {
         'hub':  ["girder_client"]
     },
-    cmdclass={'sdist': sdist, 'build_ext': build_ext, 'build_py': build_py},
+    cmdclass={'sdist': sdist, 'build_ext': build_ext},
     author="The yt project",
     author_email="yt-dev@python.org",
     url="http://yt-project.org/",

--- a/setupext.py
+++ b/setupext.py
@@ -1,64 +1,127 @@
+import contextlib
+import glob
 import os
-from pkg_resources import resource_filename
 import shutil
-from subprocess import Popen, PIPE
+import subprocess
 import sys
 import tempfile
 
+from distutils import log
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
+from distutils.errors import CompileError, LinkError
+from pkg_resources import resource_filename
+from subprocess import Popen, PIPE
+
+
+CCODE = """
+#include <omp.h>
+#include <stdio.h>
+int main() {
+  omp_set_num_threads(2);
+  #pragma omp parallel
+  printf("nthreads=%d\\n", omp_get_num_threads());
+  return 0;
+}
+"""
+
+@contextlib.contextmanager
+def stdchannel_redirected(stdchannel, dest_filename):
+    """
+    A context manager to temporarily redirect stdout or stderr
+
+    e.g.:
+
+    with stdchannel_redirected(sys.stderr, os.devnull):
+        if compiler.has_function('clock_gettime', libraries=['rt']):
+            libraries.append('rt')
+
+    Code adapted from https://stackoverflow.com/a/17752455/1382869
+    """
+
+    try:
+        oldstdchannel = os.dup(stdchannel.fileno())
+        dest_file = open(dest_filename, 'w')
+        os.dup2(dest_file.fileno(), stdchannel.fileno())
+
+        yield
+    finally:
+        if oldstdchannel is not None:
+            os.dup2(oldstdchannel, stdchannel.fileno())
+        if dest_file is not None:
+            dest_file.close()
 
 def check_for_openmp():
-    """Returns True if local setup supports OpenMP, False otherwise"""
+    """Returns True if local setup supports OpenMP, False otherwise
+
+    Code adapted from astropy_helpers, originally written by Tom 
+    Robitaille and Curtis McCully.
+    """
 
     # See https://bugs.python.org/issue25150
-    if sys.version_info[:3] == (3, 5, 0) or os.name == 'nt':
+    if sys.version_info[:3] == (3, 5, 0):
         return False
 
     # Create a temporary directory
-    tmpdir = tempfile.mkdtemp()
-    curdir = os.getcwd()
-    exit_code = 1
+    ccompiler = new_compiler()
+    customize_compiler(ccompiler)
+
+    tmp_dir = tempfile.mkdtemp()
+    start_dir = os.path.abspath('.')
+
+    if os.name == 'nt':
+        # TODO: make this work with mingw
+        # AFAICS there's no easy way to get the compiler distutils
+        # will be using until compilation actually happens
+        compile_flag = '-openmp'
+        link_flag = ''
+    else:
+        compile_flag = '-fopenmp'
+        link_flag = '-fopenmp'
 
     try:
-        os.chdir(tmpdir)
+        os.chdir(tmp_dir)
 
-        # Get compiler invocation
-        compiler = os.getenv('CC', 'cc')
-        compiler = compiler.split(' ')
+        with open('test_openmp.c', 'w') as f:
+            f.write(CCODE)
 
-        # Attempt to compile a test script.
-        # See http://openmp.org/wp/openmp-compilers/
-        filename = r'test.c'
-        file = open(filename, 'wt', 1)
-        file.write(
-            "#include <omp.h>\n"
-            "#include <stdio.h>\n"
-            "int main() {\n"
-            "#pragma omp parallel\n"
-            "printf(\"Hello from thread %d, nthreads %d\\n\", omp_get_thread_num(), omp_get_num_threads());\n"
-            "}"
-        )
-        file.flush()
-        p = Popen(compiler + ['-fopenmp', filename],
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        output, err = p.communicate()
-        exit_code = p.returncode
-        
-        if exit_code != 0:
-            print("Compilation of OpenMP test code failed with the error: ")
-            print(err.decode('utf8'))
-            print("Disabling OpenMP support. ")
+        os.mkdir('objects')
 
-        # Clean up
-        file.close()
-    except OSError:
-        print("check_for_openmp() could not find your C compiler. "
-              "Attempted to use '%s'. " % compiler)
-        return False
+        # Compile, link, and run test program
+        with stdchannel_redirected(sys.stderr, os.devnull):
+            ccompiler.compile(['test_openmp.c'], output_dir='objects',
+                              extra_postargs=[compile_flag])
+            ccompiler.link_executable(
+                glob.glob(os.path.join('objects', '*')), 'test_openmp',
+                extra_postargs=[link_flag])
+            output = subprocess.check_output('./test_openmp').decode(
+                sys.stdout.encoding or 'utf-8').splitlines()
+
+        if 'nthreads=' in output[0]:
+            nthreads = int(output[0].strip().split('=')[1])
+            if len(output) == nthreads:
+                using_openmp = True
+            else:
+                log.warn("Unexpected number of lines from output of test "
+                         "OpenMP program (output was {0})".format(output))
+                using_openmp = False
+        else:
+            log.warn("Unexpected output from test OpenMP "
+                     "program (output was {0})".format(output))
+            using_openmp = False
+
+    except (CompileError, LinkError):
+        using_openmp = False
     finally:
-        os.chdir(curdir)
-        shutil.rmtree(tmpdir)
+        os.chdir(start_dir)
 
-    return exit_code == 0
+    if using_openmp:
+        log.warn("Using OpenMP to compile parallel extensions")
+    else:
+        log.warn("Unable to compile OpenMP test program so Cython\n"
+                 "extensions will be compiled without parallel support")
+
+    return using_openmp
 
 
 def check_for_pyembree():
@@ -124,17 +187,18 @@ def read_embree_location():
         exit_code = p.returncode
 
         if exit_code != 0:
-            print("Pyembree is installed, but I could not compile Embree test code.")
-            print("The error message was: ")
-            print(err)
-            print(fail_msg)
+            log.warn("Pyembree is installed, but I could not compile Embree "
+                     "test code.")
+            log.warn("The error message was: ")
+            log.warn(err)
+            log.warn(fail_msg)
 
         # Clean up
         file.close()
 
     except OSError:
-        print("read_embree_location() could not find your C compiler. "
-              "Attempted to use '%s'. " % compiler)
+        log.warn("read_embree_location() could not find your C compiler. "
+                 "Attempted to use '%s'. " % compiler)
         return False
 
     finally:
@@ -142,20 +206,3 @@ def read_embree_location():
         shutil.rmtree(tmpdir)
 
     return rd
-
-
-def get_mercurial_changeset_id(target_dir):
-    '''
-    Returns changeset and branch using hglib
-    '''
-    try:
-        import hglib
-    except ImportError:
-        return None
-    try:
-        with hglib.open(target_dir) as repo:
-            changeset = repo.identify(
-                id=True, branch=True).strip().decode('utf8')
-    except hglib.error.ServerError:
-        return None
-    return changeset


### PR DESCRIPTION
This PR contains changes necessary to get `yt_astro_analysis` installable with pip. Mostly, this is updating `setup.py` and `setupext.py` to look more like yt's and adding a MANIFEST.in to make sure `setupext.py` gets included. I also removed some dependencies that are already required by yt.

This also updates the citation and adds CREDITS and CONTRIBUTING files.