### PR TITLE
Add napoleon extension and error out on warnings in docs build.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = yt_astro_analysis
 SOURCEDIR     = source

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.imgmath',
     'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon'
 ]
 
 intersphinx_mapping = \


### PR DESCRIPTION
This gets rid of the warnings from the docs build. In the future, we can add a docs test.