### PR TITLE
[bugfix] fix light cone projections with weight fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 
 env:
   global:
-    GOLD_STANDARD=gold-standard-v4
+    GOLD_STANDARD=gold-standard-v5
     ROCKSTAR_DIR=$HOME/rockstar
     YT_DIR=$HOME/yt-git
     YT_DATA=$HOME/yt_test

--- a/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
+++ b/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
@@ -335,7 +335,7 @@ class LightCone(CosmologySplice):
                 pixel_area = (proper_box_size.in_cgs() / pixels)**2 #in proper cm^2
                 factor = pixel_area / (4.0 * np.pi * dL.in_cgs()**2)
                 mylog.info("Distance to slice = %s" % dL)
-                frb['field'] *= factor #in erg/s/cm^2/Hz on observer"s image plane.
+                frb['field'] *= factor #in erg/s/cm^2/Hz on observer's image plane.
 
             my_storage.result = frb
 

--- a/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
+++ b/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
@@ -335,14 +335,9 @@ class LightCone(CosmologySplice):
                 pixel_area = (proper_box_size.in_cgs() / pixels)**2 #in proper cm^2
                 factor = pixel_area / (4.0 * np.pi * dL.in_cgs()**2)
                 mylog.info("Distance to slice = %s" % dL)
-                frb[field] *= factor #in erg/s/cm^2/Hz on observer"s image plane.
+                frb['field'] *= factor #in erg/s/cm^2/Hz on observer"s image plane.
 
-            if weight_field is None:
-                my_storage.result = {"field": frb[field]}
-            else:
-                my_storage.result = {"field": (frb[field] *
-                                               frb["weight_field"]),
-                                     "weight_field": frb["weight_field"]}
+            my_storage.result = frb
 
             del output["object"]
 
@@ -365,7 +360,8 @@ class LightCone(CosmologySplice):
 
             projection_stack.append(all_storage[my_slice]["field"])
             if weight_field is not None:
-                projection_weight_stack.append(all_storage[my_slice]["field"])
+                projection_weight_stack.append(
+                    all_storage[my_slice]["weight_field"])
 
         projection_stack = self.simulation.arr(projection_stack)
         projection_weight_stack = self.simulation.arr(projection_weight_stack)
@@ -376,7 +372,7 @@ class LightCone(CosmologySplice):
         else:
             light_cone_projection = \
               projection_stack.sum(axis=0) / \
-              self.simulation.arr(projection_weight_stack).sum(axis=0)
+              projection_weight_stack.sum(axis=0)
 
         filename = os.path.join(self.output_dir, self.output_prefix)
 

--- a/yt_astro_analysis/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt_astro_analysis/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -52,13 +52,8 @@ class LightConeProjectionTest(AnswerTestingTest):
     @property
     def storage_name(self):
         return "_".join(
-            (self._type_name,
-             os.path.basename(self.parameter_file),
+            (os.path.basename(self.parameter_file),
              self.field, str(self.weight_field)))
-
-    @property
-    def description(self):
-        return self.storage_name
 
     def run(self):
         # Set up in a temp dir

--- a/yt_astro_analysis/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt_astro_analysis/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -13,6 +13,8 @@ light cone generator test
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from yt.units.yt_array import \
+    YTQuantity
 from yt.utilities.on_demand_imports import \
     _h5py as h5py
 import numpy as np
@@ -30,20 +32,33 @@ from yt.utilities.answer_testing.framework import \
     requires_sim
 
 ETC = "enzo_tiny_cosmology/32Mpc_32.enzo"
+_funits = {'density': YTQuantity(1, 'g/cm**3'),
+           'temperature': YTQuantity(1, 'K'),
+           'length': YTQuantity(1, 'cm')}
 
 @requires_module("h5py")
 class LightConeProjectionTest(AnswerTestingTest):
     _type_name = "LightConeProjection"
     _attrs = ()
  
-    def __init__(self, parameter_file, simulation_type):
+    def __init__(self, parameter_file, simulation_type,
+                 field, weight_field=None):
         self.parameter_file = parameter_file
         self.simulation_type = simulation_type
         self.ds = os.path.basename(self.parameter_file)
+        self.field = field
+        self.weight_field = weight_field
 
     @property
     def storage_name(self):
-        return os.path.basename(self.parameter_file)
+        return "_".join(
+            (self._type_name,
+             os.path.basename(self.parameter_file),
+             self.field, str(self.weight_field)))
+
+    @property
+    def description(self):
+        return self.storage_name
 
     def run(self):
         # Set up in a temp dir
@@ -57,13 +72,22 @@ class LightConeProjectionTest(AnswerTestingTest):
         lc.calculate_light_cone_solution(
             seed=123456789, filename="LC/solution.txt")
         lc.project_light_cone(
-            (600.0, "arcmin"), (60.0, "arcsec"), "density",
-            weight_field=None, save_stack=True)
+            (600.0, "arcmin"), (60.0, "arcsec"), self.field,
+            weight_field=self.weight_field, save_stack=True)
 
+        dname = "%s_%s" % (self.field, self.weight_field)
         fh = h5py.File("LC/LightCone.h5")
-        data = fh["density_None"].value
-        units = fh["density_None"].attrs["units"]
-        assert units == "g/cm**2"
+        data = fh[dname].value
+        units = fh[dname].attrs["units"]
+        if self.weight_field is None:
+            punits = _funits[self.field] * _funits['length']
+        else:
+            punits = _funits[self.field] * _funits[self.weight_field] * \
+              _funits['length']
+            wunits = fh['weight_field_%s' % self.weight_field].attrs['units']
+            pwunits = _funits[self.weight_field] * _funits['length']
+            assert wunits == str(pwunits.units)
+        assert units == str(punits.units)
         fh.close()
 
         # clean up
@@ -80,4 +104,6 @@ class LightConeProjectionTest(AnswerTestingTest):
 
 @requires_sim(ETC, "Enzo")
 def test_light_cone_projection():
-    yield LightConeProjectionTest(ETC, "Enzo")
+    yield LightConeProjectionTest(ETC, "Enzo", 'density')
+    yield LightConeProjectionTest(ETC, "Enzo", 'temperature',
+                                  weight_field='density')


### PR DESCRIPTION
This resolves Issue #36. There were a few places with improper handling of the projected weight field. The behavior of the code suggests that some functionality was not updated for changes to projections, so this has likely been broken for quite some time. I'll let the test suite run and then add a new test.