### PR TITLE
[bugfix] Fix HaloCatalog progress bar

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -442,7 +442,6 @@ class HaloCatalog(ParallelAnalysisInterface):
                 elif action_type == "filter":
                     halo_filter = action(new_halo)
                     if not halo_filter:
-                        pbar.update(my_i)
                         break
                 elif action_type == "quantity":
                     key, quantity = action

--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -467,6 +467,7 @@ class HaloCatalog(ParallelAnalysisInterface):
 
             pbar.update(my_i)
 
+        pbar.finish()
         self.catalog.sort(key=lambda a:a['particle_identifier'].to_ndarray())
         if save_catalog:
             self.save_catalog()


### PR DESCRIPTION
The HaloCatalog progress bar had an unnecessary `update` call and was missing a `finish` call.