### PR TITLE
clarify rockstar error message about using the wrong number of MPI processes

### DIFF
--- a/yt_astro_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar.py
@@ -91,9 +91,11 @@ class StandardRunner(ParallelAnalysisInterface):
         else:
             self.num_writers = min(num_writers, psize)
         if self.num_readers + self.num_writers + 1 != psize:
-            mylog.error('%i reader + %i writers + 1 server != %i mpi',
-                    self.num_readers, self.num_writers, psize)
-            raise RuntimeError
+            raise RuntimeError(
+                'The number of MPI processes (%i) does not equal the '
+                'number of readers (%i) plus the number of writers '
+                '(%i) plus 1 server' % (
+                    self.num_readers, self.num_writers, psize))
     
     def run(self, handler, wg):
         # Not inline so we just launch them directly from our MPI threads.


### PR DESCRIPTION
This makes the error message show up in the RuntimeError instead of the logging stream (which might be turned off). I also tried to phrase the error message in a clearer way.