### PR TITLE
check derived_field_list for base fields

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -501,7 +501,7 @@ class HaloCatalog(ParallelAnalysisInterface):
                       "particle_position_x", "particle_position_y",
                       "particle_position_z", "virial_radius"]:
             field_name = (field_type, field)
-            if field_name not in self.halos_ds.field_list:
+            if field_name not in self.halos_ds.derived_field_list:
                 mylog.warn("Halo dataset %s has no field %s." %
                            (self.halos_ds, str(field_name)))
                 continue


### PR DESCRIPTION
Some frontends (e.g. AHF) don't use these field names in `ds.field_list` and instead set up aliases. These fields are still in `derived_field_list` and are accessible so the fix is just to look in `derived_field_list`.