### PR TITLE
Update python version and add weekly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,16 +192,37 @@ workflows:
      jobs:
        - run-tests:
            name: "Python 3.5 tests"
-           tag: "3.5.7"
+           tag: "3.5.9"
 
        - run-tests:
            name: "Python 3.6 tests"
-           tag: "3.6.8"
+           tag: "3.6.9"
 
        - run-tests:
            name: "Python 3.7 tests"
-           tag: "3.7.2"
+           tag: "3.7.6"
+
+       - run-tests:
+           name: "Python 3.8 tests"
+           tag: "3.8.1"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.7.2"
+           tag: "3.8.1"
+
+   weekly:
+     triggers:
+       - schedule:
+           cron: "0 0 * * 2"
+           filters:
+            branches:
+              only:
+                - master
+     jobs:
+       - run-tests:
+           name: "Python 3.8 tests"
+           tag: "3.8.1"
+
+       - docs-test:
+           name: "Test docs build"
+           tag: "3.8.1"

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,6 @@ from setupext import \
 from distutils.version import LooseVersion
 import pkg_resources
 
-if sys.version_info < (2, 7) or (3, 0) < sys.version_info < (3, 5):
-    print("yt_astro_analysis currently supports Python 2.7 or versions " +
-          "newer than Python 3.5. Certain features may fail unexpectedly " +
-          "and silently with older versions.")
-    sys.exit(1)
-
 try:
     distribute_ver = \
         LooseVersion(pkg_resources.get_distribution("distribute").version)
@@ -139,11 +133,11 @@ setup(
                  "Operating System :: POSIX :: AIX",
                  "Operating System :: POSIX :: Linux",
                  "Programming Language :: C",
-                 "Programming Language :: Python :: 2",
-                 "Programming Language :: Python :: 2.7",
                  "Programming Language :: Python :: 3",
-                 "Programming Language :: Python :: 3.4",
                  "Programming Language :: Python :: 3.5",
+                 "Programming Language :: Python :: 3.6",
+                 "Programming Language :: Python :: 3.7",
+                 "Programming Language :: Python :: 3.8",
                  "Topic :: Scientific/Engineering :: Astronomy",
                  "Topic :: Scientific/Engineering :: Physics",
                  "Topic :: Scientific/Engineering :: Visualization"],
@@ -177,4 +171,5 @@ setup(
     zip_safe=False,
     scripts=[],
     ext_modules=cython_extensions + extensions,
+    python_requires='>=3.5'
 )


### PR DESCRIPTION
This adds weekly tests and updates the python versions used.

It also explicitly drops Python 2 support. We haven't been testing Python 2 for a while, nor has there really been any development, so I think this is ok to do.