### PR TITLE
save halo particles for fof and hop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,13 +159,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: python-<< parameters.tag >>-test-answers-v1
+          key: python-<< parameters.tag >>-test-answers-v2
 
       - build-and-test
 
       - save_cache:
           name: "Save test answers cache."
-          key: python-<< parameters.tag >>-test-answers-v1
+          key: python-<< parameters.tag >>-test-answers-v2
           paths:
             - ~/test_results
 

--- a/doc/source/halo_catalogs.rst
+++ b/doc/source/halo_catalogs.rst
@@ -203,6 +203,16 @@ version of Rockstar has been slightly patched and modified to run as a
 library inside of ``yt_astro_analysis``.  For installation instructions,
 see :ref:`installation-rockstar`.
 
+Saving Halo Particles
+^^^^^^^^^^^^^^^^^^^^^
+
+As of version 1.1 of ``yt_astro_analysis``, the ids of the particles
+belonging to each halo can be saved to the catalog when using either the
+:ref:`fof_finding` or :ref:`hop_finding` methods. The is enabled by default
+and can be disabled by setting ``save_particles`` to ``False`` in the
+``finder_kwargs`` dictionary, as described above. This is not supported for
+the ``yt`` version of Rockstar.
+
 .. _halo_catalog_analysis:
 
 Extra Halo Analysis

--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -496,8 +496,7 @@ class HaloCatalog(ParallelAnalysisInterface):
             particles = getattr(self.halos_ds, 'particles', None)
             if particles is not None:
                 for key in ['particle_number',
-                            'particle_index_start',
-                            'particle_index_end']:
+                            'particle_index_start']:
                     ftypes[key] = "."
                     data[key] = particles.pop(key)
 

--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -493,6 +493,12 @@ class HaloCatalog(ParallelAnalysisInterface):
                 data[key] = self.halos_ds.arr(
                     [halo[key] for halo in self.catalog])
 
+        particles = getattr(self.halos_ds, 'particles', None)
+        if particles is not None:
+            for pfield in particles:
+                data[pfield] = particles[pfield]
+                ftypes[pfield] = 'particles'
+
         save_as_dataset(self.halos_ds, filename, data,
                         field_types=ftypes, extra_attrs=extra_attrs)
 

--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -493,11 +493,17 @@ class HaloCatalog(ParallelAnalysisInterface):
                 data[key] = self.halos_ds.arr(
                     [halo[key] for halo in self.catalog])
 
-        particles = getattr(self.halos_ds, 'particles', None)
-        if particles is not None:
-            for pfield in particles:
-                data[pfield] = particles[pfield]
-                ftypes[pfield] = 'particles'
+            particles = getattr(self.halos_ds, 'particles', None)
+            if particles is not None:
+                for key in ['particle_number',
+                            'particle_start_index',
+                            'particle_end_index']:
+                    ftypes[key] = "."
+                    data[key] = particles.pop(key)
+
+                for pfield in particles:
+                    data[pfield] = particles[pfield]
+                    ftypes[pfield] = 'particles'
 
         save_as_dataset(self.halos_ds, filename, data,
                         field_types=ftypes, extra_attrs=extra_attrs)

--- a/yt_astro_analysis/halo_analysis/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog.py
@@ -496,8 +496,8 @@ class HaloCatalog(ParallelAnalysisInterface):
             particles = getattr(self.halos_ds, 'particles', None)
             if particles is not None:
                 for key in ['particle_number',
-                            'particle_start_index',
-                            'particle_end_index']:
+                            'particle_index_start',
+                            'particle_index_end']:
                     ftypes[key] = "."
                     data[key] = particles.pop(key)
 

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -171,7 +171,7 @@ def _parse_old_halo_list(data_ds, halo_list):
         particle_ds.particles = {
             'ids': member_ids,
             'particle_number': n_particles,
-            'particle_start_index': start,
-            'particle_end_index': end}
+            'particle_index_start': start,
+            'particle_index_end': end}
 
     return particle_ds

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -111,7 +111,9 @@ def _parse_old_halo_list(data_ds, halo_list):
     halo_properties = { f : (np.zeros(num_halos),unit) \
         for f, unit in zip(new_fields,new_units)}
 
-    n_particles = np.zeros(num_halos, dtype=np.int32)
+    save_particles = getattr(halo_list, "save_particles", False)
+    if save_particles:
+        n_particles = np.zeros(num_halos, dtype=np.int32)
 
     # Iterate through the halos pulling out their positions and virial quantities
     # and filling in the properties dictionary
@@ -120,20 +122,21 @@ def _parse_old_halo_list(data_ds, halo_list):
         halo_properties['particle_mass'][0][i] = halo.virial_mass().in_cgs()
         halo_properties['virial_radius'][0][i] = halo.virial_radius().in_cgs()
 
-        n_particles[i] = halo.indices.size
+        if save_particles:
+            n_particles[i] = halo.indices.size
 
         com = halo.center_of_mass().in_cgs()
         halo_properties['particle_position_x'][0][i] = com[0]
         halo_properties['particle_position_y'][0][i] = com[1]
         halo_properties['particle_position_z'][0][i] = com[2]
 
-    member_ids = np.empty(n_particles.sum(), dtype=np.int64)
-
-    i = 0
-    for halo in halo_list:
-        hsize = halo.indices.size
-        member_ids[i:i+hsize] = halo['particle_index'].astype(np.int64)
-        i += hsize
+    if save_particles:
+        i = 0
+        member_ids = np.empty(n_particles.sum(), dtype=np.int64)
+        for halo in halo_list:
+            hsize = halo.indices.size
+            member_ids[i:i+hsize] = halo['particle_index'].astype(np.int64)
+            i += hsize
 
     # Define a bounding box based on original data ds
     bbox = np.array([data_ds.domain_left_edge.in_cgs(),
@@ -162,12 +165,13 @@ def _parse_old_halo_list(data_ds, halo_list):
                                       (1 + particle_ds.current_redshift),
                                       length, "\\rm{%s}/(1+z)" % my_unit)
 
-    end = n_particles.cumsum()
-    start = end - n_particles
-    particle_ds.particles = {
-        'ids': member_ids,
-        'size': n_particles,
-        'start_index': start,
-        'end_index': end}
+    if save_particles:
+        end = n_particles.cumsum()
+        start = end - n_particles
+        particle_ds.particles = {
+            'ids': member_ids,
+            'size': n_particles,
+            'start_index': start,
+            'end_index': end}
 
     return particle_ds

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -118,7 +118,7 @@ def _parse_old_halo_list(data_ds, halo_list):
     # Iterate through the halos pulling out their positions and virial quantities
     # and filling in the properties dictionary
     for i,halo in enumerate(halo_list):
-        halo_properties['particle_identifier'][0][i] = i
+        halo_properties['particle_identifier'][0][i] = halo.id
         halo_properties['particle_mass'][0][i] = halo.virial_mass().in_cgs()
         halo_properties['virial_radius'][0][i] = halo.virial_radius().in_cgs()
 

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -131,12 +131,9 @@ def _parse_old_halo_list(data_ds, halo_list):
         halo_properties['particle_position_z'][0][i] = com[2]
 
     if save_particles:
-        i = 0
         member_ids = np.empty(n_particles.sum(), dtype=np.int64)
-        for halo in halo_list:
-            hsize = halo.indices.size
-            member_ids[i:i+hsize] = halo['particle_index'].astype(np.int64)
-            i += hsize
+        np.concatenate([halo['particle_index'].astype(np.int64)
+                        for halo in halo_list], out=member_ids)
 
     # Define a bounding box based on original data ds
     bbox = np.array([data_ds.domain_left_edge.in_cgs(),

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -166,12 +166,10 @@ def _parse_old_halo_list(data_ds, halo_list):
                                       length, "\\rm{%s}/(1+z)" % my_unit)
 
     if save_particles:
-        end = n_particles.cumsum()
-        start = end - n_particles
+        start = n_particles.cumsum() - n_particles
         particle_ds.particles = {
             'ids': member_ids,
             'particle_number': n_particles,
-            'particle_index_start': start,
-            'particle_index_end': end}
+            'particle_index_start': start}
 
     return particle_ds

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -111,6 +111,8 @@ def _parse_old_halo_list(data_ds, halo_list):
     halo_properties = { f : (np.zeros(num_halos),unit) \
         for f, unit in zip(new_fields,new_units)}
 
+    n_particles = np.zeros(num_halos, dtype=np.int32)
+
     # Iterate through the halos pulling out their positions and virial quantities
     # and filling in the properties dictionary
     for i,halo in enumerate(halo_list):
@@ -118,10 +120,20 @@ def _parse_old_halo_list(data_ds, halo_list):
         halo_properties['particle_mass'][0][i] = halo.virial_mass().in_cgs()
         halo_properties['virial_radius'][0][i] = halo.virial_radius().in_cgs()
 
+        n_particles[i] = halo.indices.size
+
         com = halo.center_of_mass().in_cgs()
         halo_properties['particle_position_x'][0][i] = com[0]
         halo_properties['particle_position_y'][0][i] = com[1]
         halo_properties['particle_position_z'][0][i] = com[2]
+
+    member_ids = np.empty(n_particles.sum(), dtype=np.int64)
+
+    i = 0
+    for halo in halo_list:
+        hsize = halo.indices.size
+        member_ids[i:i+hsize] = halo['particle_index'].astype(np.int64)
+        i += hsize
 
     # Define a bounding box based on original data ds
     bbox = np.array([data_ds.domain_left_edge.in_cgs(),
@@ -149,5 +161,13 @@ def _parse_old_halo_list(data_ds, halo_list):
         particle_ds.unit_registry.add(new_unit, particle_ds.unit_registry.lut[my_unit][0] /
                                       (1 + particle_ds.current_redshift),
                                       length, "\\rm{%s}/(1+z)" % my_unit)
-    
+
+    end = n_particles.cumsum()
+    start = end - n_particles
+    particle_ds.particles = {
+        'ids': member_ids,
+        'size': n_particles,
+        'start_index': start,
+        'end_index': end}
+
     return particle_ds

--- a/yt_astro_analysis/halo_analysis/halo_finding_methods.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding_methods.py
@@ -170,8 +170,8 @@ def _parse_old_halo_list(data_ds, halo_list):
         start = end - n_particles
         particle_ds.particles = {
             'ids': member_ids,
-            'size': n_particles,
-            'start_index': start,
-            'end_index': end}
+            'particle_number': n_particles,
+            'particle_start_index': start,
+            'particle_end_index': end}
 
     return particle_ds

--- a/yt_astro_analysis/halo_finding/halo_objects.py
+++ b/yt_astro_analysis/halo_finding/halo_objects.py
@@ -1456,6 +1456,9 @@ class HOPHaloFinder(GenericHaloFinder, HOPHaloList):
         mass in the entire volume.
         Default = None, which means the total mass is automatically
         calculated.
+    save_particles : bool
+        If True, output member particles for each halo.
+        Default: True.
 
     Examples
     --------
@@ -1463,11 +1466,13 @@ class HOPHaloFinder(GenericHaloFinder, HOPHaloList):
     >>> halos = HaloFinder(ds)
     """
     def __init__(self, ds, subvolume=None, threshold=160, dm_only=True,
-                 ptype=None, padding=0.02, total_mass=None):
+                 ptype=None, padding=0.02, total_mass=None,
+                 save_particles=True):
         if subvolume is not None:
             ds_LE = np.array(subvolume.left_edge)
             ds_RE = np.array(subvolume.right_edge)
         self.period = ds.domain_right_edge - ds.domain_left_edge
+        self.save_particles = save_particles
         self._data_source = ds.all_data()
         GenericHaloFinder.__init__(self, ds, self._data_source, padding,
                                    ptype=ptype)
@@ -1573,6 +1578,9 @@ class FOFHaloFinder(GenericHaloFinder, FOFHaloList):
         with duplicated particles for halo finidng to work. This number
         must be no smaller than the radius of the largest halo in the box
         in code units. Default = 0.02.
+    save_particles : bool
+        If True, output member particles for each halo.
+        Default: True.
 
     Examples
     --------
@@ -1580,7 +1588,7 @@ class FOFHaloFinder(GenericHaloFinder, FOFHaloList):
     >>> halos = FOFHaloFinder(ds)
     """
     def __init__(self, ds, subvolume=None, link=0.2, dm_only=True,
-                 ptype=None, padding=0.02):
+                 ptype=None, padding=0.02, save_particles=True):
         if subvolume is not None:
             ds_LE = np.array(subvolume.left_edge)
             ds_RE = np.array(subvolume.right_edge)
@@ -1588,6 +1596,7 @@ class FOFHaloFinder(GenericHaloFinder, FOFHaloList):
         self.ds = ds
         self.index = ds.index
         self.redshift = ds.current_redshift
+        self.save_particles = save_particles
         self._data_source = ds.all_data()
         GenericHaloFinder.__init__(self, ds, self._data_source, padding)
         self.padding = 0.0  # * ds["unitary"] # This should be clevererer

--- a/yt_astro_analysis/halo_finding/halo_objects.py
+++ b/yt_astro_analysis/halo_finding/halo_objects.py
@@ -18,7 +18,6 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 import math
 import numpy as np
 import os.path as path
-from functools import cmp_to_key
 from yt.extern.six.moves import zip as izip
 
 from yt.config import ytcfg


### PR DESCRIPTION
This PR adds the ability to save the particle ids belonging to each halo to the halo catalogs. This can be merged on its own, but will not be of use until support is added to yt to read the particles in. I'll update when that's ready.

This also fixes a bug introduced a while back when we stopped combining the halo lists before saving in which halo ids were no longer unique.

There's a bit of a chicken and egg problem with the yt PR to read in the particles. I'd argue this should be merged first since there are a bit lower stakes. After that, the yt PR can be merged, then I will issue another PR here adding relevant tests.

If anyone would like to tests this out, they'll need to use changes from my fork of yt. Something like this should work:
```
get fetch https://github.com/brittonsmith/yt halopart
git checkout halopart
pip install -e .
```