### PR TITLE
Remove intermediate Python versions from testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,19 +196,19 @@ workflows:
 
        - run-tests:
            name: "Python 3.6 tests"
-           tag: "3.6.9"
+           tag: "3.6.10"
 
        - run-tests:
            name: "Python 3.7 tests"
-           tag: "3.7.6"
+           tag: "3.7.7"
 
        - run-tests:
            name: "Python 3.8 tests"
-           tag: "3.8.1"
+           tag: "3.8.2"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.1"
+           tag: "3.8.2"
 
    weekly:
      triggers:
@@ -221,8 +221,8 @@ workflows:
      jobs:
        - run-tests:
            name: "Python 3.8 tests"
-           tag: "3.8.1"
+           tag: "3.8.2"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.8.1"
+           tag: "3.8.2"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,13 +132,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v3
+          key: python-<< parameters.tag >>-dependencies-v4
 
       - install-with-yt-dev
 
       - save_cache:
           name: "Save dependencies cache"
-          key: python-<< parameters.tag >>-dependencies-v3
+          key: python-<< parameters.tag >>-dependencies-v4
           paths:
             - ~/.cache/pip
             - ~/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,18 @@ workflows:
                 - master
      jobs:
        - run-tests:
+           name: "Python 3.5 tests"
+           tag: "3.5.9"
+
+       - run-tests:
+           name: "Python 3.6 tests"
+           tag: "3.6.10"
+
+       - run-tests:
+           name: "Python 3.7 tests"
+           tag: "3.7.7"
+
+       - run-tests:
            name: "Python 3.8 tests"
            tag: "3.8.2"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,14 +195,6 @@ workflows:
            tag: "3.5.9"
 
        - run-tests:
-           name: "Python 3.6 tests"
-           tag: "3.6.10"
-
-       - run-tests:
-           name: "Python 3.7 tests"
-           tag: "3.7.7"
-
-       - run-tests:
            name: "Python 3.8 tests"
            tag: "3.8.2"
 

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ setup(
         'h5py',
         'setuptools>=19.6',
         'sympy',
+        'matplotlib<3.2.0',
         'numpy',
         'cython',
         'yt>=3.5.0',


### PR DESCRIPTION
~~This adds a python 3.8 tests and some weekly tests on Mondays.~~
Apparently, I did that a while ago. This removes Python 3.6 and 3.7 from the tests and moves them to the weekly cron tests with Python 3.5 and 3.8.