### PR TITLE
update rockstar interface to rockstar-galaxies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
     steps:
       - run: |
           echo 'export GOLD_STANDARD=HEAD' >> $BASH_ENV
-          echo 'export ROCKSTAR_DIR=$HOME/rockstar' >> $BASH_ENV
+          echo 'export ROCKSTAR_DIR=$HOME/rockstar-galaxies' >> $BASH_ENV
           echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROCKSTAR_DIR' >> $BASH_ENV
           echo 'export YT_DIR=$HOME/yt-git' >> $BASH_ENV
           echo 'export YT_DATA=$HOME/yt_test' >> $BASH_ENV
@@ -52,7 +52,7 @@ commands:
           popd
           # install rockstar
           if [ ! -f $ROCKSTAR_DIR/VERSION ]; then
-              git clone https://github.com/yt-project/rockstar $ROCKSTAR_DIR
+              git clone https://bitbucket.org/pbehroozi/rockstar-galaxies $ROCKSTAR_DIR
               pushd $ROCKSTAR_DIR
               make lib
               popd
@@ -132,18 +132,18 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: python-<< parameters.tag >>-dependencies-v4
+          key: python-<< parameters.tag >>-dependencies-v5
 
       - install-with-yt-dev
 
       - save_cache:
           name: "Save dependencies cache"
-          key: python-<< parameters.tag >>-dependencies-v4
+          key: python-<< parameters.tag >>-dependencies-v5
           paths:
             - ~/.cache/pip
             - ~/venv
             - ~/yt-git
-            - ~/rockstar
+            - ~/rockstar-galaxies
 
       - restore_cache:
           name: "Restore test data cache."
@@ -159,13 +159,13 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: python-<< parameters.tag >>-test-answers-v2
+          key: python-<< parameters.tag >>-test-answers-v3
 
       - build-and-test
 
       - save_cache:
           name: "Save test answers cache."
-          key: python-<< parameters.tag >>-test-answers-v2
+          key: python-<< parameters.tag >>-test-answers-v3
           paths:
             - ~/test_results
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # The yt Astro Analysis Extension
 
-[![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](http://lists.spacepope.org/listinfo.cgi/yt-users-spacepope.org/)
-[![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](http://lists.spacepope.org/listinfo.cgi/yt-dev-spacepope.org/)
+[![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
+[![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)
 [![CircleCI](https://circleci.com/gh/yt-project/yt_astro_analysis.svg?style=svg)](https://circleci.com/gh/yt-project/yt_astro_analysis)
 [![codecov](https://codecov.io/gh/yt-project/yt_astro_analysis/branch/master/graph/badge.svg)](https://codecov.io/gh/yt-project/yt_astro_analysis)
-[![Documentation Status](https://readthedocs.org/projects/yt-astro-analysis/badge/?version=latest)](http://yt-astro-analysis.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/yt-astro-analysis/badge/?version=latest)](https://yt-astro-analysis.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/yt-astro-analysis.svg)](https://badge.fury.io/py/yt-astro-analysis)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/yt_astro_analysis.svg)](https://anaconda.org/conda-forge/yt_astro_analysis)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1458961.svg)](https://doi.org/10.5281/zenodo.1458961)
 [![Data Hub](https://img.shields.io/badge/data-hub-orange.svg)](https://hub.yt/)
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 This is yt_astro_analysis, the [yt](https://github.com/yt-project/yt) extension
 package for astrophysical analysis.  This is primarily machinery that used to be
@@ -18,6 +18,9 @@ become less astro-specifc and to allow these modules to be developed on their ow
 schedule.
 
 ## Installation
+
+Full installation documentation can also be found
+[here](https://yt-astro-analysis.readthedocs.io/en/latest/Installation.html).
 
 To install yt_astro_analysis, you will first need to 
 [install yt](https://github.com/yt-project/yt#installation). Then do,
@@ -44,13 +47,16 @@ pip install -e .
 ### Installing with Rockstar support
 
 In order to run the Rockstar halo finder from within yt_astro_analysis, you will
-need to install the
-[yt-project's fork of Rockstar](https://github.com/yt-project/rockstar) and then
-provide this path to yt_astro_analysis.  To install Rockstar, do the following:
+need to install ``rockstar-galaxies`` from either
+[John Wise's
+repository](https://bitbucket.org/jwise77/rockstar-galaxies) or [Peter
+Behroozi's
+repository](https://bitbucket.org/pbehroozi/rockstar-galaxies). To
+install Rockstar, do the following:
 
 ```
-git clone https://github.com/yt-project/rockstar
-cd rockstar
+git clone https://bitbucket.org/jwise77/rockstar-galaxies
+cd rockstar-galaxies
 make lib
 ```
 
@@ -64,8 +70,8 @@ echo <path_to_rockstar> > rockstar.cfg
 pip install -e .
 ```
 
-Finally, you'll need to make sure that the location of ``librockstar.so`` is in
-your LD_LIBRARY_PATH.
+Finally, you'll need to make sure that the location of
+``librockstar-galaxies.so`` is in your LD_LIBRARY_PATH.
 
 ```
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_rockstar>
@@ -88,17 +94,17 @@ from yt.extensions.astro_analysis.ppv_cube.api import PPVCube
 ## Contributing
 
 We really want your contributions!  As an official
-[yt-project](http://yt-project.org/) extension, everything in the
+[yt-project](https://yt-project.org/) extension, everything in the
 [yt Contributor Guide](https://github.com/yt-project/yt#contributing) applies
 here.
 
 If you'd rather make your own standalone package, we want to support that, too!
 Please, consider making your package a
-[yt extension](http://yt-project.org/extensions.html).
+[yt extension](https://yt-project.org/extensions.html).
 
 ## Resources
 
-As an extension of the [yt-project](http://yt-project.org/), the
+As an extension of the [yt-project](https://yt-project.org/), the
 [yt resources](https://github.com/yt-project/yt#resources) are available for help.
 
- * The latest documentation can be found at http://yt-astro-analysis.readthedocs.io/
+ * The latest documentation can be found at https://yt-astro-analysis.readthedocs.io/

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -37,21 +37,39 @@ like this:
 Installing with Rockstar support
 --------------------------------
 
+.. note:: As of ``yt_astro_analysis`` version 1.1, ``yt_astro_analysis``
+   runs with the most recent version of ``rockstar-galaxies``. Older
+   versions of ``rockstar`` will not work.
+
 Rockstar support requires ``yt_astro_analysis`` to be installed from source.
-In order to run the Rockstar halo finder from within ``yt_astro_analysis``,
-you will need to install the `yt-project's fork of Rockstar
-<https://github.com/yt-project/rockstar>`__ and then provide this path to
-``yt_astro_analysis``.  To install Rockstar, do the following:
+Before that, the ``rockstar-galaxies`` code must also be installed from source
+and the installation path then provided to ``yt_astro_analysis``. Two
+recommended repositories exist for installing ``rockstar-galaxies``,
+`this one <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, by the
+original author, Peter Behroozi, and
+`this one <https://bitbucket.org/jwise77/rockstar-galaxies>`__, maintained by
+John Wise.
+
+.. warning:: If using `Peter Behroozi's repository
+   <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, the following
+   command must be issued after loading the resulting halo catalog in ``yt``:
+
+.. code-block:: python
+
+   >>> ds = yt.load(...)
+   >>> ds.parameters['format_revision'] = 2
+
+To install ``rockstar-galaxies``, do the following:
 
 .. code-block:: bash
 
-   $ git clone https://github.com/yt-project/rockstar
-   $ cd rockstar
+   $ git clone https://bitbucket.org/jwise77/rockstar-galaxies
+   $ cd rockstar-galaxies
    $ make lib
 
 Then, go into the ``yt_astro_analysis`` source directory and add a file called
-"rockstar.cfg" with the path the Rockstar repo you just cloned.  Then, install
-``yt_astro_analysis``.
+"rockstar.cfg" with the path the ``rockstar-galaxies`` repo you just cloned.
+Then, install ``yt_astro_analysis``.
 
 .. code-block:: bash
 
@@ -59,8 +77,8 @@ Then, go into the ``yt_astro_analysis`` source directory and add a file called
    $ echo <path_to_rockstar> > rockstar.cfg
    $ pip install -e .
 
-Finally, you'll need to make sure that the location of ``librockstar.so`` is in
-your LD_LIBRARY_PATH.
+Finally, you'll need to make sure that the location of ``librockstar-galaxies.so``
+is in your LD_LIBRARY_PATH.
 
 .. code-block:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,8 @@ if os.path.exists("rockstar.cfg"):
     except IOError:
         print("Reading Rockstar location from rockstar.cfg failed.")
         print("Please place the base directory of your")
-        print("Rockstar install in rockstar.cfg and restart.")
-        print("(ex: \"echo '/path/to/Rockstar-0.99' > rockstar.cfg\" )")
+        print("rockstar-galaxies install in rockstar.cfg and restart.")
+        print("(ex: \"echo '/path/to/rockstar-galaxies' > rockstar.cfg\" )")
         sys.exit(1)
 
     rockstar_extdir = "yt_astro_analysis/halo_finding/rockstar"
@@ -150,10 +150,9 @@ setup(
         'h5py',
         'setuptools>=19.6',
         'sympy',
-        'matplotlib<3.2.0',
         'numpy',
         'cython',
-        'yt>=3.5.0',
+        'yt>=3.6.0',
     ],
     extras_require = {
         'dev':  dev_requirements,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if os.path.exists("rockstar.cfg"):
     ]
     for ext in rockstar_extensions:
         ext.library_dirs.append(rd)
-        ext.libraries.append("rockstar")
+        ext.libraries.append("rockstar-galaxies")
         ext.define_macros.append(("THREADSAFE", ""))
         ext.include_dirs += [rd,
                              os.path.join(rd, "io"), os.path.join(rd, "util")]

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar.py
@@ -149,12 +149,12 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         recognized as star particles.
     force_res : float
         This parameter specifies the force resolution that Rockstar uses
-        in units of Mpc/h.
+        in units of Mpccm/h (comoving Mpc/h).
         If no value is provided, this parameter is automatically set to
         the width of the smallest grid element in the simulation from the
         last data snapshot (i.e. the one where time has evolved the
         longest) in the time series:
-        ``ds_last.index.get_smallest_dx().in_units("Mpc/h")``.
+        ``ds_last.index.get_smallest_dx().to("Mpccm/h")``.
     initial_metric_scaling : float
         The position element of the fof distance metric is divided by this
         parameter, set to 1 by default. If the initial_metric_scaling=0.1 the
@@ -183,14 +183,14 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         internally.  This is useful for multi-dm-mass simulations. Note that
         this will only give sensible results for halos that are not "polluted"
         by lower resolution particles. Default: ``None``.
-        
+
     Returns
     -------
     None
 
     Examples
     --------
-    
+
     To use the script below you must run it using MPI:
     mpirun -np 4 python run_rockstar.py
 
@@ -248,7 +248,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         self.min_halo_size = min_halo_size
         if force_res is None:
             tds = ts[-1] # Cache a reference
-            self.force_res = tds.arr(tds.index.get_smallest_dx(), 'code_length').in_units("Mpc/h")
+            self.force_res = tds.index.get_smallest_dx().to("Mpccm/h")
             # We have to delete now to wipe the index
             del tds
         else:

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar.py
@@ -404,10 +404,3 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             self.runner.run(self.handler, self.workgroup)
         self.comm.barrier()
         self.pool.free_all()
-
-    def halo_list(self,file_name='out_0.list'):
-        """
-        Reads in the out_0.list file and generates RockstarHaloList
-        and RockstarHalo objects.
-        """
-        return RockstarHaloList(self.ts[0], self.outbase+'/%s'%file_name)

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar.py
@@ -6,7 +6,7 @@ Operations to get Rockstar loaded up
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013-2017, yt Development Team.
+# Copyright (c) yt Development Team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -16,8 +16,6 @@ Operations to get Rockstar loaded up
 from yt.config import ytcfg
 from yt.data_objects.time_series import \
     DatasetSeries
-from yt.extern import \
-    six
 from yt.funcs import \
     is_root, mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
@@ -40,7 +38,6 @@ import socket
 import time
 import os
 import numpy as np
-from os import path
 
 class InlineRunner(ParallelAnalysisInterface):
     def __init__(self):
@@ -149,6 +146,12 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
     particle_type : str
         This is the "particle type" that can be found in the data.  This can be
         a filtered particle or an inherent type.
+    star_types : str list/array
+        The types (as returned by data((particle_type, particle_type)) to be
+        recognized as star particles.
+    multi_mass : bool
+        If True all the particle species in particle_type will be passed to
+        Rockstar even if they have different masses
     force_res : float
         This parameter specifies the force resolution that Rockstar uses
         in units of Mpc/h.
@@ -157,6 +160,17 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         last data snapshot (i.e. the one where time has evolved the
         longest) in the time series:
         ``ds_last.index.get_smallest_dx().in_units("Mpc/h")``.
+    initial_metric_scaling : float
+        The position element of the fof distance metric is divided by this
+        parameter, set to 1 by default. If the initial_metric_scaling=0.1 the
+        position element will have 10 times more weight than the velocity element,
+        biasing the metric towards position information more so than velocity
+        information. That was found to be needed for hydro-ART simulations
+        with 10's of parsecs resolution.
+    non_dm_metric_scaling : float
+        The metric scaling to be used for non-dm particles (not yet supported).
+    suppress_galaxies : int
+        Wether to include non-dm halos (i.e. galaxies) in the catalogs (not yet supported).
     total_particles : int
         If supplied, this is a pre-calculated total number of particles present
         in the simulation. For example, this is useful when analyzing a series
@@ -202,15 +216,17 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
 
     """
     def __init__(self, ts, num_readers = 1, num_writers = None,
-            outbase="rockstar_halos", particle_type="all",
-            force_res=None, total_particles=None, dm_only=False,
-            particle_mass=None, min_halo_size=25):
+                 outbase="rockstar_halos", particle_type="all", star_types=[], multi_mass=False,
+                 force_res=None, initial_metric_scaling=1.0, non_dm_metric_scaling=10.0,
+                 suppress_galaxies=1, total_particles=None, dm_only=False, particle_mass=None,
+                 min_halo_size=25):
+
         if is_root():
             mylog.info("The citation for the Rockstar halo finder can be found at")
             mylog.info("http://adsabs.harvard.edu/abs/2013ApJ...762..109B")
         ParallelAnalysisInterface.__init__(self)
         # Decide how we're working.
-        if ytcfg.getboolean("yt", "inline") is True:
+        if ytcfg.getboolean("yt", "inline") == True:
             self.runner = InlineRunner()
         else:
             self.runner = StandardRunner(num_readers, num_writers)
@@ -225,15 +241,20 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             ts = DatasetSeries([ts])
         self.ts = ts
         self.particle_type = particle_type
-        self.outbase = six.b(outbase)
+        self.star_types = star_types
+        self.multi_mass = multi_mass
+        self.outbase = bytearray(outbase, 'utf-8')
         self.min_halo_size = min_halo_size
         if force_res is None:
             tds = ts[-1] # Cache a reference
-            self.force_res = tds.index.get_smallest_dx().in_units("Mpc/h")
+            self.force_res = tds.arr(tds.index.get_smallest_dx(), 'code_length').in_units("Mpc/h")
             # We have to delete now to wipe the index
             del tds
         else:
             self.force_res = force_res
+        self.initial_metric_scaling = initial_metric_scaling
+        self.non_dm_metric_scaling = non_dm_metric_scaling
+        self.suppress_galaxies = suppress_galaxies
         self.total_particles = total_particles
         self.dm_only = dm_only
         self.particle_mass = particle_mass
@@ -255,14 +276,16 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
 
         dd = tds.all_data()
         # Get DM particle mass.
+        all_fields = set(tds.derived_field_list + tds.field_list)
+        has_particle_type = ("particle_type" in all_fields)
 
         particle_mass = self.particle_mass
         if particle_mass is None:
             pmass_min, pmass_max = dd.quantities.extrema(
                 (ptype, "particle_mass"), non_zero = True)
-            if np.abs(pmass_max - pmass_min) / pmass_max > 0.01:
-                raise YTRockstarMultiMassNotSupported(pmass_min, pmass_max,
-                    ptype)
+            if (np.abs(pmass_max - pmass_min) / pmass_max > 0.01) and (self.multi_mass==False):
+                raise YTRockstarMultiMassNotSupported(pmass_min, pmass_max, ptype)
+                print ('Set multi_mass=True if you are using a Rockstar version with multi-mass support')
             particle_mass = pmass_min
 
         p = {}
@@ -307,8 +330,8 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             server_address, port = None, None
         self.server_address, self.port = self.comm.mpi_bcast(
             (server_address, port))
-        self.server_address = six.b(str(self.server_address))
-        self.port = six.b(str(self.port))
+        self.server_address = bytearray(str(self.server_address), 'utf-8')
+        self.port = bytearray(str(self.port), 'utf-8')
 
     def run(self, block_ratio = 1, callbacks = None, restart = False):
         """
@@ -339,11 +362,10 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             self.ts._pre_outputs = self.ts._pre_outputs[restart_num:]
         else:
             restart_num = 0
-        self.handler.setup_rockstar(
-                    self.server_address,
-                    self.port,
+        self.handler.setup_rockstar(self.server_address, self.port,
                     num_outputs, self.total_particles, 
                     self.particle_type,
+                    star_types = self.star_types,
                     particle_mass = self.particle_mass,
                     parallel = self.comm.size > 1,
                     num_readers = self.num_readers,
@@ -352,6 +374,9 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
                     block_ratio = block_ratio,
                     outbase = self.outbase,
                     force_res = self.force_res,
+                    initial_metric_scaling = self.initial_metric_scaling,
+                    non_dm_metric_scaling = self.non_dm_metric_scaling,
+                    suppress_galaxies = self.suppress_galaxies,
                     callbacks = callbacks,
                     restart_num = restart_num,
                     min_halo_size = self.min_halo_size)
@@ -363,10 +388,10 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
                 os.makedirs(self.outbase)
             # Make a record of which dataset corresponds to which set of
             # output files because it will be easy to lose this connection.
-            fp = open(self.outbase.decode() + '/datasets.txt', 'w')
+            fp = open(self.outbase.decode('utf-8') + '/datasets.txt', 'w')
             fp.write("# dsname\tindex\n")
             for i, ds in enumerate(self.ts):
-                dsloc = path.join(path.relpath(ds.fullpath), ds.basename)
+                dsloc = os.path.join(os.path.relpath(ds.fullpath), ds.basename)
                 line = "%s\t%d\n" % (dsloc, i)
                 fp.write(line)
             fp.close()
@@ -379,3 +404,10 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             self.runner.run(self.handler, self.workgroup)
         self.comm.barrier()
         self.pool.free_all()
+
+    def halo_list(self,file_name='out_0.list'):
+        """
+        Reads in the out_0.list file and generates RockstarHaloList
+        and RockstarHalo objects.
+        """
+        return RockstarHaloList(self.ts[0], self.outbase+'/%s'%file_name)

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -27,6 +27,10 @@ cdef import from "particle.h":
     struct particle:
         np.int64_t id
         float pos[6]
+        float mass, energy
+        float softening
+        float metallicity
+        np.int32_t type
 
 ctypedef struct particleflat:
     np.int64_t id
@@ -36,6 +40,10 @@ ctypedef struct particleflat:
     float vel_x
     float vel_y
     float vel_z
+    float mass, energy
+    float softening
+    float metallicity
+    np.int32_t type
 
 cdef import from "halo.h":
     struct halo:
@@ -47,6 +55,9 @@ cdef import from "halo.h":
         float m, r, child_r, mgrav, vmax, rvmax, rs, vrms, energy, spin
         np.int64_t num_p, num_child_particles, p_start, desc, flags, n_core
         float min_pos_err, min_vel_err, min_bulkvel_err
+
+        np.int32_t type
+        float sm, gas, bh, peak_density, av_density
 
 cdef import from "io_generic.h":
     ctypedef void (*LPG) (char *filename, particle **p, np.int64_t *num_p)
@@ -81,6 +92,9 @@ cdef import from "config_vars.h":
     char *MASS_DEFINITION
     np.int64_t MIN_HALO_OUTPUT_SIZE
     np.float64_t FORCE_RES
+    np.float64_t INITIAL_METRIC_SCALING
+    np.float64_t NON_DM_METRIC_SCALING
+    np.int64_t SUPPRESS_GALAXIES
 
     np.float64_t SCALE_NOW
     np.float64_t h0
@@ -168,21 +182,38 @@ cdef void rh_analyze_halo(halo *h, particle *hp):
     if h.num_p == 0: return
     cdef particleflat[:] pslice
     pslice = <particleflat[:h.num_p]> (<particleflat *>hp)
-    parray = np.asarray(pslice)
+
+    '''
+    parray = np.asarray(pslice) # This line produces the following error
+
+    #project/projectdirs/agora/.AGORA_PIPE_INSTALL/yt-agora_install/lib/python2.7/site-packages/numpy/core/numeric.py:320: RuntimeWarning: Item size computed from the PEP 3118 buffer format string does not match the actual item size.
+    #return array(a, dtype, copy=False, order=order)
+    #Exception TypeError: 'expected a readable buffer object' in 'yt.analysis_modules.halo_finding.rockstar.rockstar_interface.rh_analyze_halo' ignored
+
+    # This is where we call our functions
     for cb in rh.callbacks:
         cb(rh.ds, parray)
-    # This is where we call our functions
+    ''' 
 
 cdef void rh_read_particles(char *filename, particle **p, np.int64_t *num_p):
     global SCALE_NOW
     cdef np.float64_t left_edge[6]
-    cdef np.ndarray[np.int64_t, ndim=1] arri
-    cdef np.ndarray[np.float64_t, ndim=1] arr
+    cdef np.ndarray[np.int64_t, ndim=1] arri #index
+    cdef np.ndarray[np.float64_t, ndim=1] arr # pos/vel
+    cdef np.ndarray[np.float64_t, ndim=1] marr # mass
+    #cdef np.ndarray[np.float64_t, ndim=1] earr # energy
+    #cdef np.ndarray[np.float64_t, ndim=1] sarr # softening
+    #cdef np.ndarray[np.float64_t, ndim=1] mtarr # metalicity
+    cdef np.ndarray[np.int32_t, ndim=1] tarr # type
     cdef unsigned long long pi,fi,i
     cdef np.int64_t local_parts = 0
     ds = rh.ds = next(rh.tsl)
+    n = rh.block_ratio
 
     SCALE_NOW = 1.0/(ds.current_redshift+1.0)
+    # Now we want to grab data from only a subset of the grids for each reader.
+    all_fields = set(ds.derived_field_list + ds.field_list)
+
     # First we need to find out how many this reader is going to read in
     # if the number of readers > 1.
     dd = ds.all_data()
@@ -209,9 +240,24 @@ cdef void rh_read_particles(char *filename, particle **p, np.int64_t *num_p):
     for chunk in parallel_objects(dd.chunks([], "io")):
         arri = np.asarray(chunk[rh.particle_type, "particle_index"],
                           dtype="int64")
+        marr = chunk[rh.particle_type, "particle_mass"].in_units("Msun/h").astype("float64")
+        #earr = chunk[rh.particle_type, "particle_"].in_units("").astype("float64")
+        #sarr = chunk[rh.particle_type, "particle_"].in_units("").astype("float64")
+        #mtarr= chunk[rh.particle_type, "particle_"].in_units("").astype("float64")
+        tarr = np.asarray(chunk[rh.particle_type, "particle_type"], dtype="int32")
         npart = arri.size
         for i in range(npart):
             p[0][i+pi].id = <np.int64_t> arri[i]
+            p[0][i+pi].mass = <np.float64_t> marr[i]
+            #p[0][i+pi].energy = <np.float64_t> earr[i]
+            #p[0][i+pi].softening = <np.float64_t> sarr[i]
+            #p[0][i+pi].metallicity = <np.float64_t> mtarr[i]
+            if tarr[i] in rh.star_types:
+                type = 2
+            else:
+                type = 0
+            p[0][i+pi].type = <np.int32_t> type
+
         fi = 0
         for field in ["particle_position_x", "particle_position_y",
                       "particle_position_z",
@@ -239,6 +285,7 @@ cdef class RockstarInterface:
     cdef int size
     cdef public int block_ratio
     cdef public object particle_type
+    cdef public object star_types
     cdef public int total_particles
     cdef public object callbacks
 
@@ -247,24 +294,33 @@ cdef class RockstarInterface:
         self.tsl = ts.__iter__() #timeseries generator used by read
 
     def setup_rockstar(self, char *server_address, char *server_port,
-                       int num_snaps, np.int64_t total_particles,
-                       particle_type,
+                       int num_snaps, int total_particles,
+                       particle_type, star_types,
                        np.float64_t particle_mass,
                        int parallel = False, int num_readers = 1,
                        int num_writers = 1,
                        int writing_port = -1, int block_ratio = 1,
-                       int periodic = 1, force_res=None,
-                       int min_halo_size = 25, outbase = "None",
-                       callbacks = None, int restart_num = 0):
+                       outbase = "None",
+                       force_res = None,
+                       initial_metric_scaling = 1,
+                       non_dm_metric_scaling = 10,
+                       int suppress_galaxies = 1,
+                       callbacks = None, int restart_num = 0,
+                       int periodic = 1, int min_halo_size = 25,):
         global PARALLEL_IO, PARALLEL_IO_SERVER_ADDRESS, PARALLEL_IO_SERVER_PORT
         global FILENAME, FILE_FORMAT, NUM_SNAPS, STARTING_SNAP, h0, Ol, Om
         global BOX_SIZE, PERIODIC, PARTICLE_MASS, NUM_BLOCKS, NUM_READERS
         global FORK_READERS_FROM_WRITERS, PARALLEL_IO_WRITER_PORT, NUM_WRITERS
-        global rh, SCALE_NOW, OUTBASE, MIN_HALO_OUTPUT_SIZE, OUTPUT_FORMAT
+        global rh, SCALE_NOW, OUTBASE, MIN_HALO_OUTPUT_SIZE,
         global OVERLAP_LENGTH, TOTAL_PARTICLES, FORCE_RES, RESTART_SNAP
+        global INITIAL_METRIC_SCALING, NON_DM_METRIC_SCALING, SUPPRESS_GALAXIES
+
         if force_res is not None:
             FORCE_RES=np.float64(force_res)
             #print "set force res to ",FORCE_RES
+        INITIAL_METRIC_SCALING=np.float64(initial_metric_scaling)
+        NON_DM_METRIC_SCALING=np.float64(non_dm_metric_scaling)
+        SUPPRESS_GALAXIES=np.int64(suppress_galaxies)
         OVERLAP_LENGTH = 0.0
         if parallel:
             PARALLEL_IO = 1
@@ -288,6 +344,7 @@ cdef class RockstarInterface:
         TOTAL_PARTICLES = total_particles
         self.block_ratio = block_ratio
         self.particle_type = particle_type
+        self.star_types = star_types
 
         tds = self.ts[0]
         h0 = tds.hubble_constant
@@ -296,15 +353,14 @@ cdef class RockstarInterface:
         SCALE_NOW = 1.0/(tds.current_redshift+1.0)
         if callbacks is None: callbacks = []
         self.callbacks = callbacks
-        if not outbase == 'None'.encode('UTF-8'):
+        if not outbase =='None':
             #output directory. since we can't change the output filenames
             #workaround is to make a new directory
             OUTBASE = outbase
 
         PARTICLE_MASS = particle_mass
         PERIODIC = periodic
-        BOX_SIZE = (tds.domain_right_edge[0] -
-                    tds.domain_left_edge[0]).in_units("Mpccm/h")
+        BOX_SIZE = tds.domain_width[0].in_units("Mpccm/h")
         setup_config()
         rh = self
         cdef LPG func = rh_read_particles

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -202,17 +202,14 @@ cdef void rh_read_particles(char *filename, particle **p, np.int64_t *num_p):
     ds = rh.ds = next(rh.tsl)
 
     SCALE_NOW = 1.0/(ds.current_redshift+1.0)
-    # Now we want to grab data from only a subset of the grids for each reader.
-    all_fields = set(ds.derived_field_list + ds.field_list)
-
-    # First we need to find out how many this reader is going to read in
-    # if the number of readers > 1.
-    dd = ds.all_data()
 
     # Add particle type filter if not defined
     if rh.particle_type not in ds.particle_types and rh.particle_type != 'all':
         ds.add_particle_filter(rh.particle_type)
 
+    # First we need to find out how many this reader is going to read in
+    # if the number of readers > 1.
+    dd = ds.all_data()
     if NUM_BLOCKS > 1:
         local_parts = 0
         for chunk in parallel_objects(
@@ -229,6 +226,7 @@ cdef void rh_read_particles(char *filename, particle **p, np.int64_t *num_p):
     left_edge[2] = dle[2]
     left_edge[3] = left_edge[4] = left_edge[5] = 0.0
     pi = 0
+    # Now we want to grab data from only a subset of the grids for each reader.
     for chunk in parallel_objects(dd.chunks([], "io")):
         arri = np.asarray(chunk[rh.particle_type, "particle_index"], dtype="int64")
         marr = chunk[rh.particle_type, "particle_mass"].to("Msun/h").astype("float64")

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -27,9 +27,10 @@ cdef import from "particle.h":
     struct particle:
         np.int64_t id
         float pos[6]
-        float mass, energy
-        float softening
-        float metallicity
+        float mass
+        # float energy
+        # float softening
+        # float metallicity
         np.int32_t type
 
 ctypedef struct particleflat:
@@ -40,9 +41,10 @@ ctypedef struct particleflat:
     float vel_x
     float vel_y
     float vel_z
-    float mass, energy
-    float softening
-    float metallicity
+    float mass
+    # float energy
+    # float softening
+    # float metallicity
     np.int32_t type
 
 cdef import from "halo.h":

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -345,7 +345,7 @@ cdef class RockstarInterface:
         SCALE_NOW = 1.0/(tds.current_redshift+1.0)
         if callbacks is None: callbacks = []
         self.callbacks = callbacks
-        if not outbase =='None':
+        if not outbase == 'None':
             #output directory. since we can't change the output filenames
             #workaround is to make a new directory
             OUTBASE = outbase

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -57,7 +57,6 @@ cdef import from "halo.h":
         float m, r, child_r, mgrav, vmax, rvmax, rs, vrms, energy, spin
         np.int64_t num_p, num_child_particles, p_start, desc, flags, n_core
         float min_pos_err, min_vel_err, min_bulkvel_err
-
         np.int32_t type
 
 cdef import from "io_generic.h":
@@ -184,7 +183,6 @@ cdef void rh_analyze_halo(halo *h, particle *hp):
     cdef particleflat[:] pslice
     pslice = <particleflat[:h.num_p]> (<particleflat *>hp)
     parray = np.asarray(pslice)
-
     for cb in rh.callbacks:
         cb(rh.ds, parray)
     # This is where we call our functions

--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -182,18 +182,11 @@ cdef void rh_analyze_halo(halo *h, particle *hp):
     if h.num_p == 0: return
     cdef particleflat[:] pslice
     pslice = <particleflat[:h.num_p]> (<particleflat *>hp)
+    parray = np.asarray(pslice)
 
-    '''
-    parray = np.asarray(pslice) # This line produces the following error
-
-    #project/projectdirs/agora/.AGORA_PIPE_INSTALL/yt-agora_install/lib/python2.7/site-packages/numpy/core/numeric.py:320: RuntimeWarning: Item size computed from the PEP 3118 buffer format string does not match the actual item size.
-    #return array(a, dtype, copy=False, order=order)
-    #Exception TypeError: 'expected a readable buffer object' in 'yt.analysis_modules.halo_finding.rockstar.rockstar_interface.rh_analyze_halo' ignored
-
-    # This is where we call our functions
     for cb in rh.callbacks:
         cb(rh.ds, parray)
-    ''' 
+    # This is where we call our functions
 
 cdef void rh_read_particles(char *filename, particle **p, np.int64_t *num_p):
     global SCALE_NOW
@@ -317,7 +310,6 @@ cdef class RockstarInterface:
 
         if force_res is not None:
             FORCE_RES=np.float64(force_res)
-            #print "set force res to ",FORCE_RES
         INITIAL_METRIC_SCALING=np.float64(initial_metric_scaling)
         NON_DM_METRIC_SCALING=np.float64(non_dm_metric_scaling)
         SUPPRESS_GALAXIES=np.int64(suppress_galaxies)

--- a/yt_astro_analysis/halo_finding/tests/test_rockstar.py
+++ b/yt_astro_analysis/halo_finding/tests/test_rockstar.py
@@ -31,10 +31,12 @@ def test_rockstar():
 
     h1 = "rockstar_halos/halos_0.0.bin"
     d1 = load(h1)
+    d1.parameters['format_revision'] = 2
     for field in _fields:
         yield FieldValuesTest(d1, field, particle_type=True, decimals=1)
     h2 = "rockstar_halos/halos_1.0.bin"
     d2 = load(h2)
+    d2.parameters['format_revision'] = 2
     for field in _fields:
         yield FieldValuesTest(d2, field, particle_type=True, decimals=1)
 


### PR DESCRIPTION
In this PR, I've extracted the relevant changes from the [Agora project yt PR](https://bitbucket.org/yt_analysis/yt/pull-requests/1560/yt-agora/diff) to update the rockstar interface to use rockstar-galaxies. It was too difficult to preserve the history, so I overlaid the changed files and did a fair amount of cleanup until the diff looked sensible. There may still be more things to clean up, but this first pass was mainly about typos, extra whitespace, applying later changes, and making things work with Python 3.

I think this is a safe move to make. There have been very few changes to rockstar-galaxies in recent years and probably longer since the API changed. There are also some other stable forks (like [this one](https://bitbucket.org/jwise77/rockstar-galaxies)) that can be used and pointed to in the documentation.

Update: docs and setup updated. This can be merged anytime.