### PR TITLE
Fix iterator

### DIFF
--- a/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -280,7 +280,7 @@ cdef class RockstarInterface:
 
     def __cinit__(self, ts):
         self.ts = ts
-        self.tsl = ts.__iter__() #timeseries generator used by read
+        self.tsl = iter(ts)  # timeseries generator used by read
 
     def setup_rockstar(self, char *server_address, char *server_port,
                        int num_snaps, int total_particles,


### PR DESCRIPTION
This fixes the rockstar frontend, which was broken in recent version of yt as the __iter__ function was removed.
The same behaviour can still be achieved the iter keyword.