### PR TITLE
Add restart option for rockstar

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
@@ -179,6 +179,11 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         If supplied, use this as the particle mass supplied to rockstar.
         Otherwise, particle masses are read from the dataset.
         Default: ``None``.
+    restart : optional, bool
+        Set to True to have rockstar restart from the first uncompleted
+        snapshot. If False, rockstar will start at the first snapshot in the
+        simulation.
+        Default: False
 
     Returns
     -------

--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
@@ -203,7 +203,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
                  outbase="rockstar_halos", particle_type="all", star_types=None,
                  force_res=None, initial_metric_scaling=1.0, non_dm_metric_scaling=10.0,
                  suppress_galaxies=1, total_particles=None, dm_only=False, particle_mass=None,
-                 min_halo_size=25):
+                 min_halo_size=25, restart=False):
 
         if is_root():
             mylog.info("The citation for the Rockstar halo finder can be found at")
@@ -214,6 +214,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             self.runner = InlineRunner()
         else:
             self.runner = StandardRunner(num_readers, num_writers)
+        self.restart = restart
         self.num_readers = self.runner.num_readers
         self.num_writers = self.runner.num_writers
         mylog.info("Rockstar is using %d readers and %d writers",
@@ -321,6 +322,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         self._get_hosts()
         # Find restart output number
         num_outputs = len(self.ts)
+        restart = restart or self.restart
         if restart:
             restart_file = os.path.join(self.outbase, "restart.cfg")
             if not os.path.exists(restart_file):


### PR DESCRIPTION
This adds a ``restart`` keyword to the rockstar halo finder allowing it to be restarted from the first uncompleted snapshot.