### PR TITLE
Allow more flexibility for specifying rockstar particle mass

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,11 +49,12 @@ extensions = [
 intersphinx_mapping = \
   {'yt': ('http://yt-project.org/docs/dev/', None),
    'trident': ('http://trident.readthedocs.io/en/latest/', None),
+   'unyt': ('https://unyt.readthedocs.io/en/stable/', None),
    'http://docs.python.org/': None,
    'http://ipython.org/ipython-doc/stable/': None,
    'http://docs.scipy.org/doc/numpy/': None,
    'http://matplotlib.org/': None,
-  'http://docs.astropy.org/en/stable': None,}
+   'http://docs.astropy.org/en/stable': None,}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This allows the user to specify the rockstar particle mass as either a float with assumed units of Msun/h, a tuple of (<value>, <unit>), or a unyt_quantity. This is both bugfix and enhancement because specifying as a float (as documented) didn't work correctly.