### PR TITLE
MNT: cleanup requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,11 +36,8 @@ project_urls =
 
 [options]
 install_requires =
-    h5py
-    more_itertools
-    numpy
-    sympy
-    unyt
+    h5py>=3.1.0,<4.0.0
+    more_itertools>=8.4
     yt>=4.0.1
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
most of yt_astro's dependencies are directly inherited from yt and they are not going away any time soon.
I'm keeping `more_itertools` as a direct dependency because it could be refactored out of yt (in principle), and `h5py` because it's not a hard dependency to yt itself.