### PR TITLE
ENH: simplify test scripts and migrate some static metadata from setup.py to setup.cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,7 @@ commands:
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
-            pip install --upgrade wheel
-            pip install --upgrade setuptools
-            pip install Cython numpy
-            pip install -e .[dev]
+            pip install .[dev]
 
   install-with-yt-dev:
     description: "Install dependencies with yt from source."
@@ -47,9 +44,7 @@ commands:
             python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
-            pip install --upgrade wheel
-            pip install --upgrade setuptools
-            pip install Cython mpi4py numpy
+            pip install mpi4py
             export MAX_BUILD_CORES=2
             # install yt from source
             if [ ! -f $YT_DIR/README.md ]; then
@@ -58,7 +53,7 @@ commands:
             pushd $YT_DIR
             git pull origin main
             git checkout main
-            pip install -e .
+            pip install .
             popd
             # install rockstar
             sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100
@@ -70,7 +65,7 @@ commands:
             fi
             echo $ROCKSTAR_DIR > rockstar.cfg
             # install yt_astro_analysis with extra dev dependencies
-            pip install -e .[dev]
+            pip install .[dev]
             # configure yt
             yt config set --global yt suppress_stream_logging True
             yt config set --global yt test_data_dir $YT_DATA

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,22 @@ python_requires = >=3.7,<3.12
 include_package_data = True
 zip_safe = False
 
+[options.extras_require]
+dev =
+    astropy
+    codecov
+    flake8
+    girder-client
+    gitpython
+    nose
+    nose-timer
+    pytest
+    scipy
+    sphinx
+    sphinx-bootstrap-theme
+    twine
+    wheel
+
 [nosetests]
 detailed-errors = 1
 exclude = answer_testing

--- a/setup.py
+++ b/setup.py
@@ -64,22 +64,6 @@ extensions = [
     ),
 ]
 
-dev_requirements = [
-    "astropy",
-    "codecov",
-    "flake8",
-    "girder-client",
-    "gitpython",
-    "nose",
-    "nose-timer",
-    "pytest",
-    "scipy",
-    "sphinx",
-    "sphinx_bootstrap_theme",
-    "twine",
-    "wheel",
-]
-
 # ROCKSTAR
 if os.path.exists("rockstar.cfg"):
     try:
@@ -147,8 +131,5 @@ setup(
     long_description=long_description,
     cmdclass={"sdist": sdist, "build_ext": build_ext},
     ext_modules=cython_extensions + extensions,
-    extras_require={
-        "dev": dev_requirements,
-    },
     packages=find_packages(),
 )


### PR DESCRIPTION
A couple simplifications that I found while working on setting up automatic wheels