### PR TITLE
ENH: add support for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,8 +240,8 @@ workflows:
            tag: "3.7.12"
 
        - run-tests:
-           name: "Python 3.9 tests"
-           tag: "3.9.7"
+           name: "Python 3.10 tests"
+           tag: "3.10.0"
 
        - docs-test:
            name: "Test docs build"
@@ -267,6 +267,10 @@ workflows:
        - run-tests:
            name: "Python 3.9 tests"
            tag: "3.9.7"
+
+       - run-tests:
+           name: "Python 3.10 tests"
+           tag: "3.10.0"
 
        - docs-test:
            name: "Test docs build"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     rev: v1.20.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--max-py-version, '3.9']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Topic :: Scientific/Engineering :: Visualization


### PR DESCRIPTION
The only dependency that doesn't already ship Python 3.10 wheels is yt itself (and I expect we'll do it for the upcoming bugfix release), so it should be ok now to test against the newest Python and declare compatibility. I just hope that this won't increase build time on CI in any significant way while we have to build yt from source.