### PR TITLE
REL: automate wheels publication to PyPI

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -37,3 +37,32 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'yt_astro_analysis-'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/yt_astro_analysis-')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
Based off #116
Fix #117

inspired by https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml

opening as a draft
@brittonsmith, we need to first create a PYPI_TOKEN for this to work, I can walk you through it if you want