### PR TITLE
Make sure to initialize index before checking particle types.

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
@@ -297,6 +297,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         if self.workgroup.name != "readers":
             return None
         tds = ts[0]
+        tds.index
         ptype = self.particle_type
         if ptype not in tds.particle_types and ptype != "all":
             has_particle_filter = tds.add_particle_filter(ptype)


### PR DESCRIPTION
The available particle types won't be known unless the index is initialized first. This can happen when doing halo finding on time-series.