### PR TITLE
remove overly protective upper limit to h5py version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,7 @@ requires = [
   "setuptools>=19.6",
   # see https://github.com/numpy/numpy/pull/18389
   "wheel>=0.36.2",
-
-  # cython version is imposed by that of numpy, see release notes
-  # https://github.com/numpy/numpy/releases/tag/v1.19.2
-  # Cython 3.0 is the next version after 0.29, and a major change,
-  # we forbid it until we can properly test against it
-  "Cython>=0.26.1,<3.0; python_version=='3.6'",
-  "Cython>=0.29.21,<3.0; python_version>='3.7'",
+  "Cython>=0.29.21,<3.0",
   "oldest-supported-numpy",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 
 [options]
 install_requires =
-    h5py>=3.1.0,<4.0.0
+    h5py>=3.1.0
     more-itertools>=8.4
     yt>=4.0.1
 python_requires = >=3.7,<3.12


### PR DESCRIPTION
noticed this while working on the conda-forge recipe. This upper limit is arbitrary and doesn't correspond to a known issue, hence it has the potential of causing more harm than good, might as well remove it now since we're doing a patch release