### PR TITLE
Make total particles a 64 bit integer.

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
@@ -395,7 +395,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             self.server_address,
             self.port,
             num_outputs,
-            self.total_particles,
+            np.int64(self.total_particles),
             self.particle_type,
             self.mass_field,
             star_types=self.star_types,

--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar_interface.pyx
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar_interface.pyx
@@ -283,7 +283,7 @@ cdef class RockstarInterface:
     cdef public object particle_type
     cdef public object mass_field
     cdef public object star_types
-    cdef public int total_particles
+    cdef public np.int64_t total_particles
     cdef public object callbacks
 
     def __cinit__(self, ts):
@@ -291,7 +291,7 @@ cdef class RockstarInterface:
         self.tsl = iter(ts)  # timeseries generator used by read
 
     def setup_rockstar(self, char *server_address, char *server_port,
-                       int num_snaps, int total_particles,
+                       int num_snaps, np.int64_t total_particles,
                        particle_type, mass_field, star_types,
                        np.float64_t particle_mass,
                        int parallel = False, int num_readers = 1,


### PR DESCRIPTION
This prevents integer overflow when the number of particles exceeds the 32 bit signed integer limit. I've tested this out on a dataset producing this error and it works.