### PR TITLE
Set output directory properly for rockstar halo finder.

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -115,7 +115,7 @@ class HaloCatalog(ParallelAnalysisInterface):
         halo_field_type="all",
         finder_method=None,
         finder_kwargs=None,
-        output_dir="halo_catalogs",
+        output_dir=None,
     ):
 
         super().__init__()
@@ -134,8 +134,11 @@ class HaloCatalog(ParallelAnalysisInterface):
             data_source = halos_ds.all_data()
         self.data_source = data_source
 
-        if finder_method == "rockstar":
-            output_dir = finder_kwargs.get("outbase", "rockstar_halos")
+        if output_dir is None:
+            if finder_method == "rockstar":
+                output_dir = finder_kwargs.get("outbase", "rockstar_halos")
+            else:
+                output_dir = "halo_catalogs"
 
         self.output_basedir = ensure_dir(output_dir)
         self.pipeline = AnalysisPipeline(output_dir=self.output_dir)

--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -134,6 +134,9 @@ class HaloCatalog(ParallelAnalysisInterface):
             data_source = halos_ds.all_data()
         self.data_source = data_source
 
+        if finder_method == "rockstar":
+            output_dir = finder_kwargs.get("outbase", "rockstar_halos")
+
         self.output_basedir = ensure_dir(output_dir)
         self.pipeline = AnalysisPipeline(output_dir=self.output_dir)
         self.quantities = self.pipeline.quantities


### PR DESCRIPTION
Rockstar manages its own output directory creation. Prior to this, if you ran rockstar, you end up with halo catalogs in rockstar's output directory as determined by the `outbase` rockstar option and then an empty `halo_catalogs` directory written by the `HaloCatalog`. This PR just adds a little sync-up between those two so you don't end up with this extra directory.