### PR TITLE
Update package name for conda/pip installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 [![PyPI version](https://badge.fury.io/py/yt-astro-analysis.svg)](https://badge.fury.io/py/yt-astro-analysis)
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/yt_astro_analysis.svg)](https://anaconda.org/conda-forge/yt_astro_analysis)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/yt-astro-analysis/badges/version.svg)](https://anaconda.org/conda-forge/yt-astro-analysis)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1458961.svg)](https://doi.org/10.5281/zenodo.1458961)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
@@ -39,13 +39,16 @@ Full installation documentation can also be found
 
 Get the latest release via pip as
 ```shell
-python -m pip install yt_astro_analysis
+python -m pip install yt-astro-analysis
 ```
 
 Or with conda, as
 ```shell
-conda install -c conda-forge yt_astro_analysis
+conda install -c conda-forge yt-astro-analysis
 ```
+
+Note, the package name is spelled with hyphens (`yt-astro-analysis`)
+when installing from pip or conda.
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ conda install -c conda-forge yt-astro-analysis
 ```
 
 Note, the package name is spelled with hyphens (`yt-astro-analysis`)
-when installing from pip or conda.
+when installing from pip or conda. With pip, the package name can be
+spelled with either hyphens or underscores, but with conda it must
+always be hyphens.
 
 ### From source
 

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -20,7 +20,9 @@ from conda-forge:
    $ conda install -c conda-forge yt-astro-analysis
 
 Note, the package name is spelled with hyphens (``yt-astro-analysis``)
-when installing from pip or conda.
+when installing from pip or conda. With pip, the package name can be
+spelled with either hyphens or underscores, but with conda it must
+always be hyphens.
 
 Installing from source
 ----------------------

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -10,14 +10,17 @@ that, ``yt_astro_analysis`` can be installed with pip:
 
 .. code-block:: bash
 
-   $ pip install yt_astro_analysis
+   $ pip install yt-astro-analysis
 
 If you use ``conda`` to manage packages, you can install ``yt_astro_analysis``
 from conda-forge:
 
 .. code-block:: bash
 
-   $ conda install -c conda-forge yt_astro_analysis
+   $ conda install -c conda-forge yt-astro-analysis
+
+Note, the package name is spelled with hyphens (``yt-astro-analysis``)
+when installing from pip or conda.
 
 Installing from source
 ----------------------


### PR DESCRIPTION
Conda changed the package name associated with this package from `yt_astro_analysis` to `yt-astro-analysis`, i.e., changing the underscores to hyphens. If you do:
```
conda install yt_astro_analysis
```
you will be stuck on version 1.0. You can only get 1.1 and beyond by installing with the new name. With pip, you can install with either naming convention. For simplicity, I've changed the conda/pip installation instructions to both use hyphenized name. I've also updated the conda badge to point at the right package.