### PR TITLE
Increase timeout on data download.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ commands:
     steps:
       - run:
           name: "Download test data."
+          no_output_timeout: 20m
           command: |
             if [ ! -f $YT_DATA/enzo_tiny_cosmology/DD0046/DD0046 ]; then
                 source $BASH_ENV


### PR DESCRIPTION
This should prevent the testing on circleci from timing out.

Fixes Issue #146.