### PR TITLE
BLD: switch ubuntu image to 20.04 (18.04 image is deprecated)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
     tags: 'yt_astro_analysis-*'
-
+  pull_request:
+     paths:
+       - .github/workflows/wheels.yaml
   workflow_dispatch:
 
 jobs:
@@ -15,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [
-          ubuntu-18.04,
+          ubuntu-20.04,
           windows-2019,
           macos-10.15,
         ]


### PR DESCRIPTION
ref: https://github.com/actions/runner-images/issues/6002