### PR TITLE
BLD: build wheels for Python 3.11

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -27,11 +27,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@v2.11.4
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64"

--- a/yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c
+++ b/yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c
@@ -54,7 +54,7 @@ Py_EnzoFOF(PyObject *obj, PyObject *args)
 
     xpos    = (PyArrayObject *) PyArray_FromAny(oxpos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if(!xpos){
     PyErr_Format(_FOFerror,
              "EnzoFOF: xpos didn't work.");
@@ -64,7 +64,7 @@ Py_EnzoFOF(PyObject *obj, PyObject *args)
 
     ypos    = (PyArrayObject *) PyArray_FromAny(oypos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if((!ypos)||(PyArray_SIZE(ypos) != num_particles)) {
     PyErr_Format(_FOFerror,
              "EnzoFOF: xpos and ypos must be the same length.");
@@ -73,7 +73,7 @@ Py_EnzoFOF(PyObject *obj, PyObject *args)
 
     zpos    = (PyArrayObject *) PyArray_FromAny(ozpos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if((!zpos)||(PyArray_SIZE(zpos) != num_particles)) {
     PyErr_Format(_FOFerror,
              "EnzoFOF: xpos and zpos must be the same length.");

--- a/yt_astro_analysis/halo_analysis/halo_finding/hop/EnzoHop.c
+++ b/yt_astro_analysis/halo_analysis/halo_finding/hop/EnzoHop.c
@@ -46,7 +46,7 @@ int convert_particle_arrays(
 
     *xpos    = (PyArrayObject *) PyArray_FromAny(oxpos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if(!*xpos){
     PyErr_Format(_HOPerror,
              "EnzoHop: xpos didn't work.");
@@ -56,7 +56,7 @@ int convert_particle_arrays(
 
     *ypos    = (PyArrayObject *) PyArray_FromAny(oypos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if((!*ypos)||(PyArray_SIZE(*ypos) != num_particles)) {
     PyErr_Format(_HOPerror,
              "EnzoHop: xpos and ypos must be the same length.");
@@ -65,7 +65,7 @@ int convert_particle_arrays(
 
     *zpos    = (PyArrayObject *) PyArray_FromAny(ozpos,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if((!*zpos)||(PyArray_SIZE(*zpos) != num_particles)) {
     PyErr_Format(_HOPerror,
              "EnzoHop: xpos and zpos must be the same length.");
@@ -74,7 +74,7 @@ int convert_particle_arrays(
 
     *mass    = (PyArrayObject *) PyArray_FromAny(omass,
                     PyArray_DescrFromType(NPY_FLOAT64), 1, 1,
-                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_UPDATEIFCOPY, NULL);
+                    NPY_ARRAY_INOUT_ARRAY | NPY_ARRAY_WRITEBACKIFCOPY, NULL);
     if((!*mass)||(PyArray_SIZE(*mass) != num_particles)) {
     PyErr_Format(_HOPerror,
              "EnzoHop: xpos and mass must be the same length.");


### PR DESCRIPTION
Cherry picking the relevant bits from #163

- BLD: add CPython 3.11 to supported wheels
- BLD: fix building on CPython 3.11 (migrate away from deprecated numpy C-API)
