### PR TITLE
MNT: bump github action versions

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -19,7 +19,7 @@ jobs:
         os: [
           ubuntu-20.04,
           windows-2019,
-          macos-10.15,
+          macos-12,
         ]
       fail-fast: false
 

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build wheels for CPython
         uses: pypa/cibuildwheel@v2.11.4
@@ -39,7 +39,7 @@ jobs:
           CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"
           CIBW_BUILD_VERBOSITY: 1
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: ./dist/*.whl
@@ -48,12 +48,12 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: tarball
           path: dist/*.tar.gz
@@ -64,17 +64,17 @@ jobs:
     # upload to PyPI on every tag starting with 'yt_astro_analysis-'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/yt_astro_analysis-')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: tarball
           path: dist
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
get rid of deprecation warnings

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```