### PR TITLE
STY: upgrade black to 23.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - id: pyupgrade
       args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
     - id: black
 -   repo: https://github.com/PyCQA/isort
@@ -44,7 +44,7 @@ repos:
     rev: 1.13.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==22.12.0]
+        additional_dependencies: [black==23.1.0]
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/doc/source/halo_catalog.rst
+++ b/doc/source/halo_catalog.rst
@@ -78,7 +78,6 @@ An example of defining your own filter:
 .. code-block:: python
 
    def my_filter_function(halo):
-
        # Define condition for filter
        filter_value = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,6 @@ include-package-data = true
 zip-safe = false
 
 [tool.black]
-line-length = 88
-target-version = [
-  'py38',
-  'py39',
-  'py310',
-]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/yt_astro_analysis/cosmological_observation/cosmology_splice.py
+++ b/yt_astro_analysis/cosmological_observation/cosmology_splice.py
@@ -157,7 +157,6 @@ class CosmologySplice:
 
         # Use minimum number of datasets to go from z_i to z_f.
         if minimal:
-
             z_Tolerance = 1e-3
             z = far_redshift
 
@@ -171,7 +170,6 @@ class CosmologySplice:
             while (z_target > near_redshift) and (
                 np.abs(z_target - near_redshift) > z_Tolerance
             ):
-
                 # Move forward from last slice in stack until z > z_max.
                 current_slice = cosmology_splice[-1]
 

--- a/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
+++ b/yt_astro_analysis/cosmological_observation/light_cone/light_cone.py
@@ -104,7 +104,6 @@ class LightCone(CosmologySplice):
         output_dir="LC",
         output_prefix="LightCone",
     ):
-
         self.near_redshift = near_redshift
         self.far_redshift = far_redshift
         self.observer_redshift = observer_redshift

--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -117,7 +117,6 @@ class HaloCatalog(ParallelAnalysisInterface):
         finder_kwargs=None,
         output_dir=None,
     ):
-
         super().__init__()
 
         self.halos_ds = halos_ds
@@ -199,7 +198,6 @@ class HaloCatalog(ParallelAnalysisInterface):
         return os.path.join(self.output_basedir, self.output_basename)
 
     def _yield_halos(self, njobs="auto", dynamic=False):
-
         my_size = self.comm.size
 
         if njobs == "auto":
@@ -211,7 +209,6 @@ class HaloCatalog(ParallelAnalysisInterface):
             my_njobs = njobs
 
         for chunk in self.data_source.chunks([], "io"):
-
             if self.comm.rank == 0:
                 chunk.get_data(self.pipeline.field_quantities)
 
@@ -280,7 +277,6 @@ class HaloCatalog(ParallelAnalysisInterface):
             data = {}
             if n_halos > 0:
                 for key in self.quantities:
-
                     if hasattr(self.catalog[0][key], "units"):
                         registry = self.catalog[0][key].units.registry
                         my_arr = functools.partial(unyt_array, registry=registry)

--- a/yt_astro_analysis/halo_analysis/halo_catalog/plot_modifications.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/plot_modifications.py
@@ -121,7 +121,6 @@ class HaloCatalogCallback(PlotCallback):
         font_kwargs=None,
         factor=1.0,
     ):
-
         PlotCallback.__init__(self)
         def_circle_args = {"edgecolor": "white", "facecolor": "None"}
         def_text_args = {"color": "white"}

--- a/yt_astro_analysis/halo_analysis/halo_finding/halo_objects.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/halo_objects.py
@@ -574,7 +574,6 @@ class FOFHalo(Halo):
 
 
 class HaloList:
-
     _fields = ["particle_position_%s" % ax for ax in "xyz"]
 
     def __init__(self, data_source, redshift=-1, ptype="all"):

--- a/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/rockstar/rockstar.py
@@ -242,7 +242,6 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
         min_halo_size=25,
         restart=False,
     ):
-
         if is_root():
             mylog.info("The citation for the Rockstar halo finder can be found at")
             mylog.info("http://adsabs.harvard.edu/abs/2013ApJ...762..109B")
@@ -343,7 +342,6 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
 
     def _get_hosts(self):
         if self.comm.rank == 0 or self.comm.size == 1:
-
             # Temporary mac hostname fix
             try:
                 server_address = socket.gethostname()

--- a/yt_astro_analysis/ppv_cube/tests/test_ppv.py
+++ b/yt_astro_analysis/ppv_cube/tests/test_ppv.py
@@ -27,7 +27,6 @@ def setup():
 
 
 def test_ppv():
-
     np.random.seed(seed=0x4D3D3D3)
 
     dims = (8, 8, 128)
@@ -83,7 +82,6 @@ def test_ppv():
 
 
 def test_ppv_nothermalbroad():
-
     np.random.seed(seed=0x4D3D3D3)
 
     dims = (16, 16, 128)

--- a/yt_astro_analysis/radmc3d_export/tests/test_radmc3d_exporter.py
+++ b/yt_astro_analysis/radmc3d_export/tests/test_radmc3d_exporter.py
@@ -40,7 +40,6 @@ class RadMC3DValuesTest(AnswerTestingTest):
         self.decimals = decimals
 
     def run(self):
-
         # Set up in a temp dir
         tmpdir = tempfile.mkdtemp()
         curdir = os.getcwd()
@@ -55,7 +54,6 @@ class RadMC3DValuesTest(AnswerTestingTest):
         total = 0.0
         with open("dust_density.inp") as f:
             for i, line in enumerate(f):
-
                 # skip header
                 if i < 3:
                     continue


### PR DESCRIPTION
black 23.1.0 is now able to infer target version from the project metadata (namely `requires-python = ">=3.8"`) so it's a small opportunity for simplifying config and reducing the number of places where we need to keep track of supported versions
I'm also removing the `line-length` parameter because it's set to the default value, so it's not doing anything