### PR TITLE
[WIP] Fix PPVCube

### DIFF
--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -132,7 +132,6 @@ class PPVCube:
         """
 
         self.ds = ds
-        self.field = field
         self.width = width
         self.particle_mass = atomic_weight * mh
         self.thermal_broad = thermal_broad
@@ -166,6 +165,7 @@ class PPVCube:
 
         dd = ds.all_data()
         fd = dd._determine_fields(field)[0]
+        self.field = fd
         ftype = fd[0]
         self.field_units = ds._get_field_info(fd).units
 
@@ -314,8 +314,8 @@ class PPVCube:
 
         Notes
         -----
-        Additional keyword arguments are passed to
-        :meth:`~astropy.io.fits.HDUList.writeto`.
+        All other optional arguments are passed to
+        :meth:`~yt.visualization.fits_image.FITSImageData.create_sky_wcs`.
 
         Examples
         --------
@@ -345,8 +345,8 @@ class PPVCube:
 
         fib = FITSImageData(self.data, fields=self.field, wcs=w)
         if sky_scale is not None and sky_center is not None:
-            fib.create_sky_wcs(sky_center, sky_scale)
-        fib.writeto(filename, overwrite=overwrite, **kwargs)
+            fib.create_sky_wcs(sky_center, sky_scale, **kwargs)
+        fib.writeto(filename, overwrite=overwrite)
 
     def __repr__(self):
         return "PPVCube [%d %d %d] (%s < %s < %s)" % (

--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -343,9 +343,7 @@ class PPVCube:
         w.wcs.cunit = [units, units, vunit]
         w.wcs.ctype = ["LINEAR", "LINEAR", vtype]
 
-        fib = FITSImageData(self.data.transpose(), fields=self.field, wcs=w)
-        fib.update_all_headers("bunit", re.sub("()", "", str(self.proj_units)))
-        fib.update_all_headers("btype", self.field)
+        fib = FITSImageData(self.data, fields=self.field, wcs=w)
         if sky_scale is not None and sky_center is not None:
             fib.create_sky_wcs(sky_center, sky_scale)
         fib.writeto(filename, overwrite=overwrite, **kwargs)

--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -197,7 +197,7 @@ class PPVCube:
 
         if method == "integrate" and weight_field is None:
             self.proj_units = str(ds.quan(1.0, self.field_units + "*cm").units)
-        elif method == "sum":
+        else:
             self.proj_units = self.field_units
 
         storage = {}

--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -201,7 +201,7 @@ class PPVCube:
             self.proj_units = self.field_units
 
         storage = {}
-        pbar = get_pbar("Generating cube.", self.nv)
+        pbar = get_pbar("Generating cube", self.nv)
         for sto, i in parallel_objects(range(self.nv), storage=storage):
             self.current_v = self.vmid_cgs[i]
             if isinstance(normal, str):

--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -212,7 +212,7 @@ class PPVCube:
                     weight_field=weight_field,
                     data_source=data_source,
                 )
-                buf = prj.to_frb(width, self.nx, center=self.center)["intensity"]
+                buf = prj.to_frb(width, self.nx, center=self.center)[ftype, "intensity"]
             else:
                 if data_source is None:
                     source = ds

--- a/yt_astro_analysis/ppv_cube/ppv_cube.py
+++ b/yt_astro_analysis/ppv_cube/ppv_cube.py
@@ -77,7 +77,6 @@ class PPVCube:
         thermal_broad=False,
         atomic_weight=56.0,
         depth=(1.0, "unitary"),
-        depth_res=256,
         method="integrate",
         weight_field=None,
         no_shifting=False,
@@ -127,9 +126,6 @@ class PPVCube:
             A tuple containing the depth to project through and the string
             key of the unit: (width, 'unit').  If set to a float, code units
             are assumed. Only for off-axis cubes.
-        depth_res : integer, optional
-            Deprecated, this is still in the function signature for API
-            compatibility
         method : string, optional
             Set the projection method to be used.
             "integrate" : line of sight integration over the line element.


### PR DESCRIPTION
The `PPVCube` class is out of date with both yt and yt_astro_analysis. This PR brings it up to date, in particular:

* Removes deprecated keyword argument `depth_res`, which was originally here for off-axis projections and is now long gone in yt.
* Does not assume that the field type will always be `"gas"`.
* Uses `sampling_type="local"` in fields to allow for SPH projections.
* Makes sure field tuples are always used.
* Removes code used to create line-of-sight velocity fields and uses the built-in yt functionality for this purpose. 

Still need to fix the docs, hence WIP. This appears to have uncovered a bug in yt which I'll have to resolve separately. 