### PR TITLE
self.finder_method wasn't setting halos_ds

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -305,8 +305,6 @@ class HaloCatalog(ParallelAnalysisInterface):
 
         if self.halos_ds is None:
             self.halos_ds = YTHaloCatalogDataset(filename)
-        if self.data_source is None:
-            self.data_source = self.halos_ds.all_data()
 
     def create(self, save_halos=False, save_output=True, njobs="auto", dynamic=False):
         r"""

--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -12,8 +12,8 @@ import numpy as np
 from unyt import unyt_array
 
 from yt.data_objects.time_series import DatasetSeries
-from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.frontends.halo_catalog.data_structures import YTHaloCatalogDataset
+from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import ensure_dir, mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,

--- a/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
+++ b/yt_astro_analysis/halo_analysis/halo_catalog/halo_catalog.py
@@ -13,6 +13,7 @@ from unyt import unyt_array
 
 from yt.data_objects.time_series import DatasetSeries
 from yt.frontends.ytdata.utilities import save_as_dataset
+from yt.frontends.halo_catalog.data_structures import YTHaloCatalogDataset
 from yt.funcs import ensure_dir, mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
@@ -301,6 +302,11 @@ class HaloCatalog(ParallelAnalysisInterface):
             save_as_dataset(
                 ds, filename, data, field_types=field_types, extra_attrs=extra_attrs_d
             )
+
+        if self.halos_ds is None:
+            self.halos_ds = YTHaloCatalogDataset(filename)
+        if self.data_source is None:
+            self.data_source = self.halos_ds.all_data()
 
     def create(self, save_halos=False, save_output=True, njobs="auto", dynamic=False):
         r"""


### PR DESCRIPTION
The call to self.finder_method in _run does not set halos_ds, which means that even though the halo catalog was being generated and saved to disk, the actual HaloCatalog object was not being updated and thus remains unusable. Now if the halo catalog is being saved to disk, set halos_ds if it has not already been set.

I'm not sure if this is the best location for this, since it's really more about fixing an issue in the _run function, but this was the only location that has access to the actual dataset. Likewise, I'm not sure if using YTHaloCatalogDataset directly here is correct or if there's a better way to do it.  If both of these issues are correct, I can add a test for this bug too.