### PR TITLE
TST: treat warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,7 @@ known-third-party = [
   "glue",
 ]
 known-first-party = ["yt", "yt_astro_analysis"]
+
+
+[tool.pytest]
+filterwarnings = ["error"]


### PR DESCRIPTION
Just noticed we are not yet paying any attention to deprecation warnings and whatnot.