### PR TITLE
MNT: cleanup free of uninitialized variable

### DIFF
--- a/yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c
+++ b/yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c
@@ -159,8 +159,6 @@ _fail:
     Py_XDECREF(ypos);
     Py_XDECREF(zpos);
 
-    if(kd->p!=NULL)free(kd->p);
-
     return NULL;
 
 }


### PR DESCRIPTION
fix the following compilation warning
```
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -DOPENSSL_NO_SSL3 -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/private/var/folders/xh/yfmp7l9n3x50ln2yvrndt7c801pbkm/T/build-env-sk2pigg1/include -I/Users/robcleme/.pyenv/versions/3.9.17/include/python3.9 -I/private/var/folders/xh/yfmp7l9n3x50ln2yvrndt7c801pbkm/T/build-env-sk2pigg1/lib/python3.9/site-packages/numpy/core/include -c yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c -o build/temp.macosx-13.4-x86_64-cpython-39/yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.o
yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c:162:8: warning: variable 'kd' is uninitialized when used here [-Wuninitialized]
    if(kd->p!=NULL)free(kd->p);
       ^~
yt_astro_analysis/halo_analysis/halo_finding/fof/EnzoFOF.c:36:10: note: initialize the variable 'kd' to silence this warning
        KDFOF kd;
                ^
                 = NULL
1 warning generated.
```

As far as I can tell this is the last compilation warning that is actionable at the moment.