### PR TITLE
BLD: migrate from oldest-supported-numpy to NPY_TARGET_VERSION (Python >= 3.9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 requires = [
   "setuptools>=61.2",
   "Cython>=3.0",
-  "oldest-supported-numpy ; python_version < '3.12.0rc1'",
-  "numpy>=1.26.0b1 ; python_version >= '3.12.0rc1'",
+  "oldest-supported-numpy ; python_version < '3.9'",
+  "numpy>=1.25,<2.0  ; python_version >= '3.9' and python_version < '3.12.0rc1'",
+  "numpy>=1.26.0b1,<2.0 ; python_version >= '3.12.0rc1'",
 ]
 
 [project]
@@ -40,7 +41,8 @@ requires-python = ">=3.8"
 dependencies = [
     "h5py>=3.1.0",
     "yt>=4.0.1",
-    # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
+    # when Python 3.8 is dropped, keep minimal requirement in sync with NPY_TARGET_VERSION
+    # upper cap should be lifted when build-time requirement is bumped to >=2.0, see
     "numpy>=1.17.5,<2.0",
     "packaging>=20.9",
 ]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,14 @@ else:
     std_libs = ["m"]
 
 
-define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+define_macros = [
+    ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
+]
+if sys.version_info >= (3, 9):
+    # keep in sync with runtime requirements (pyproject.toml)
+    define_macros.append(("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION"))
+else:
+    pass
 
 cython_extensions = [
     Extension(


### PR DESCRIPTION
requires #216
