### PR TITLE
Support installation of rockstar through conda

### DIFF
--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -47,22 +47,32 @@ Installing with Rockstar support
    versions of ``rockstar`` will not work.
 
 Rockstar support requires ``yt_astro_analysis`` to be installed from source.
-Before that, the ``rockstar-galaxies`` code must also be installed from source
-and the installation path then provided to ``yt_astro_analysis``. Two
+Before that, the ``rockstar-galaxies`` code must also be installed.
+
+Using ``conda``
+^^^^^^^^^^^^^^^
+
+If you are using ``conda`` to manage packages, you can install ``rockstar-galaxies`` as follows
+.. code-block:: bash
+
+   $ conda install -c conda-forge rockstar-galaxies
+
+Then, go into the ``yt_astro_analysis`` source directory and install it.
+
+.. code-block:: bash
+
+   $ cd yt_astro_analysis
+   $ pip install -e .
+
+Building ``rockstar-galaxies`` from source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Alternatively, you can install ``rockstar-galaxies`` from source. Two
 recommended repositories exist for installing ``rockstar-galaxies``,
 `this one <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, by the
 original author, Peter Behroozi, and
 `this one <https://bitbucket.org/jwise77/rockstar-galaxies>`__, maintained by
 John Wise.
-
-.. warning:: If using `Peter Behroozi's repository
-   <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, the following
-   command must be issued after loading the resulting halo catalog in ``yt``:
-
-.. code-block:: python
-
-   ds = yt.load(...)
-   ds.parameters["format_revision"] = 2
 
 To install ``rockstar-galaxies``, do the following:
 
@@ -82,9 +92,19 @@ Then, install ``yt_astro_analysis``.
    $ echo <path_to_rockstar> > rockstar.cfg
    $ pip install -e .
 
-Finally, you'll need to make sure that the location of ``librockstar-galaxies.so``
-is in your LD_LIBRARY_PATH.
+Finally, if you installed rockstar-galaxies from source, you'll need to make sure that
+the location of ``librockstar-galaxies.so`` is in your LD_LIBRARY_PATH.
 
 .. code-block:: bash
 
    $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_rockstar>
+
+
+.. warning:: If using the conda version or building from source with `Peter Behroozi's repository
+   <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, the following
+   command must be issued after loading the resulting halo catalog in ``yt``:
+
+.. code-block:: python
+
+   ds = yt.load(...)
+   ds.parameters["format_revision"] = 2

--- a/doc/source/Installation.rst
+++ b/doc/source/Installation.rst
@@ -49,10 +49,20 @@ Installing with Rockstar support
 Rockstar support requires ``yt_astro_analysis`` to be installed from source.
 Before that, the ``rockstar-galaxies`` code must also be installed.
 
-Using ``conda``
-^^^^^^^^^^^^^^^
+.. warning:: If using the conda version or building from source with `Peter Behroozi's repository
+   <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, the following
+   command must be issued after loading the resulting halo catalog in ``yt``:
+
+.. code-block:: python
+
+   ds = yt.load(...)
+   ds.parameters["format_revision"] = 2
+
+Installing ``rockstar-galaxies`` through ``conda``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you are using ``conda`` to manage packages, you can install ``rockstar-galaxies`` as follows
+
 .. code-block:: bash
 
    $ conda install -c conda-forge rockstar-galaxies
@@ -64,8 +74,8 @@ Then, go into the ``yt_astro_analysis`` source directory and install it.
    $ cd yt_astro_analysis
    $ pip install -e .
 
-Building ``rockstar-galaxies`` from source
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing ``rockstar-galaxies`` from source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Alternatively, you can install ``rockstar-galaxies`` from source. Two
 recommended repositories exist for installing ``rockstar-galaxies``,
@@ -98,13 +108,3 @@ the location of ``librockstar-galaxies.so`` is in your LD_LIBRARY_PATH.
 .. code-block:: bash
 
    $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<path_to_rockstar>
-
-
-.. warning:: If using the conda version or building from source with `Peter Behroozi's repository
-   <https://bitbucket.org/pbehroozi/rockstar-galaxies/>`__, the following
-   command must be issued after loading the resulting halo catalog in ``yt``:
-
-.. code-block:: python
-
-   ds = yt.load(...)
-   ds.parameters["format_revision"] = 2

--- a/setup.py
+++ b/setup.py
@@ -91,11 +91,9 @@ if os.path.exists("rockstar.cfg"):
     _paths_to_try.append(rd)
 
 if "CONDA_PREFIX" in os.environ:
-    _paths_to_try.append(os.path.join(
-        os.environ["CONDA_PREFIX"],
-        "include",
-        "rockstar-galaxies"
-    ))
+    _paths_to_try.append(
+        os.path.join(os.environ["CONDA_PREFIX"], "include", "rockstar-galaxies")
+    )
 
 for rd in _paths_to_try:
     if not os.path.exists(rd):

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ extensions = [
 ]
 
 # ROCKSTAR
+_paths_to_try = []
 if os.path.exists("rockstar.cfg"):
     try:
         rd = open("rockstar.cfg").read().strip()
@@ -87,7 +88,19 @@ if os.path.exists("rockstar.cfg"):
         print("rockstar-galaxies install in rockstar.cfg and restart.")
         print("(ex: \"echo '/path/to/rockstar-galaxies' > rockstar.cfg\" )")
         sys.exit(1)
+    _paths_to_try.append(rd)
 
+if "CONDA_PREFIX" in os.environ:
+    _paths_to_try.append(os.path.join(
+        os.environ["CONDA_PREFIX"],
+        "include",
+        "rockstar-galaxies"
+    ))
+
+for rd in _paths_to_try:
+    if not os.path.exists(rd):
+        continue
+    print(f"BUILDING with ROCKSTAR in {rd}")
     rockstar_extdir = "yt_astro_analysis/halo_analysis/halo_finding/rockstar"
     rockstar_extensions = [
         Extension(
@@ -107,6 +120,8 @@ if os.path.exists("rockstar.cfg"):
         ext.define_macros.append(("THREADSAFE", ""))
         ext.include_dirs += [rd, os.path.join(rd, "io"), os.path.join(rd, "util")]
     extensions += rockstar_extensions
+
+    break
 
 
 CYTHONIZE_KWARGS = {


### PR DESCRIPTION
rockstar can now be installed through conda. This simplifies the installation process as it needs not be compiled manually.

Eventually on Linux, we may want (or not?) to set rockstar as a hard dependency on our conda-forge build so that the support is automatic.