### PR TITLE
DEP: drop support for CPython 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,24 +279,20 @@ workflows:
    normal-tests:
      jobs:
        - run-tests:
-           name: "Python 3.8 tests"
-           tag: "3.8.16"
-
-       - run-tests:
            name: "Python 3.9 tests"
-           tag: "3.9.16"
+           tag: "3.9"
 
        - run-tests-pytest:
            name: "Python 3.10 tests"
-           tag: "3.10.9"
+           tag: "3.10"
 
        - run-tests-pytest:
            name: "Python 3.11 tests"
-           tag: "3.11.1"
+           tag: "3.11"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.16"
+           tag: "3.9"
 
    weekly:
      triggers:
@@ -308,13 +304,13 @@ workflows:
                 - main
      jobs:
        - run-tests:
-           name: "Python 3.8 tests"
-           tag: "3.8.16"
+           name: "Python 3.9 tests"
+           tag: "3.9"
 
        - run-tests-pytest:
            name: "Python 3.11 tests"
-           tag: "3.11.1"
+           tag: "3.11"
 
        - docs-test:
            name: "Test docs build"
-           tag: "3.9.16"
+           tag: "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 requires = [
   "setuptools>=61.2",
   "Cython>=3.0",
-  "oldest-supported-numpy ; python_version < '3.9'",
-  "numpy>=1.25,<2.0  ; python_version >= '3.9' and python_version < '3.12.0rc1'",
-  "numpy>=1.26.0b1,<2.0 ; python_version >= '3.12.0rc1'",
+  "numpy>=1.25, <2.0",
 ]
 
 [project]
@@ -26,7 +24,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,13 +34,12 @@ classifiers = [
 keywords = [
     "astronomy astrophysics visualization amr adaptivemeshrefinement",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "h5py>=3.1.0",
     "yt>=4.0.1",
-    # when Python 3.8 is dropped, keep minimal requirement in sync with NPY_TARGET_VERSION
     # upper cap should be lifted when build-time requirement is bumped to >=2.0, see
-    "numpy>=1.17.5,<2.0",
+    "numpy>=1.19.3, <2.0",
     "packaging>=20.9",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,9 @@ else:
 
 define_macros = [
     ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-]
-if sys.version_info >= (3, 9):
     # keep in sync with runtime requirements (pyproject.toml)
-    define_macros.append(("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION"))
-else:
-    pass
+    ("NPY_TARGET_VERSION", "NPY_1_19_API_VERSION"),
+]
 
 cython_extensions = [
     Extension(


### PR DESCRIPTION
proposed solution to fix CI, which is currently failing because the dev version of yt doesn't support Python 3.8 anymore.

includes changes from #221 