### PR TITLE
BUG: fix usage of deprecated (and removed) clobber argument from astropy

### DIFF
--- a/doc/source/PPVCube.ipynb
+++ b/doc/source/PPVCube.ipynb
@@ -282,7 +282,7 @@
     }
    ],
    "source": [
-    "cube.write_fits(\"cube.fits\", clobber=True, length_unit=\"kpc\")"
+    "cube.write_fits(\"cube.fits\", overwrite=True, length_unit=\"kpc\")"
    ]
   },
   {
@@ -313,7 +313,7 @@
    "source": [
     "sky_scale = (1.0, \"arcsec/kpc\")\n",
     "sky_center = (30., 45.) # RA, Dec in degrees\n",
-    "cube.write_fits(\"cube_sky.fits\", clobber=True, sky_scale=sky_scale, sky_center=sky_center)"
+    "cube.write_fits(\"cube_sky.fits\", overwrite=True, sky_scale=sky_scale, sky_center=sky_center)"
    ]
   },
   {
@@ -574,7 +574,7 @@
    "source": [
     "cube2 = PPVCube(ds, L, \"density\", (-150.,150.,50,\"km/s\"), dims=200, thermal_broad=True, \n",
     "                atomic_weight=12.0, method=\"sum\")\n",
-    "cube2.write_fits(\"cube2.fits\", clobber=True, length_unit=\"kpc\")"
+    "cube2.write_fits(\"cube2.fits\", overwrite=True, length_unit=\"kpc\")"
    ]
   },
   {


### PR DESCRIPTION
This fixes another incompatibility seen in doc/source/PPVCube.ipynb
There are other issues with this notebook but I'll get back to it after #225 is dealt with.