### PR TITLE
TST: add CPython 3.12 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,10 @@ workflows:
            name: "Python 3.11 tests"
            tag: "3.11"
 
+       - run-tests-pytest:
+           name: "Python 3.12 tests"
+           tag: "3.12"
+
        - docs-test:
            name: "Test docs build"
            tag: "3.9"
@@ -308,8 +312,8 @@ workflows:
            tag: "3.9"
 
        - run-tests-pytest:
-           name: "Python 3.11 tests"
-           tag: "3.11"
+           name: "Python 3.12 tests"
+           tag: "3.12"
 
        - docs-test:
            name: "Test docs build"


### PR DESCRIPTION
with the release of h5py 3.10.0 (which includes cp312 wheels), this should be possible. Another potential blocker is the availability of Python 3.12 on circleCI, which I could not verify from docs, so let's just try it.