### PR TITLE
Do not use tokens for Pypi uploads

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -63,6 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'yt_astro_analysis-'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/yt_astro_analysis-')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/yt-astro-analysis
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -76,6 +81,3 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.8.14
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -64,7 +64,7 @@ jobs:
     # upload to PyPI on every tag starting with 'yt_astro_analysis-'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/yt_astro_analysis-')
     environment:
-      name: pypi
+      name: upload_pypi
       url: https://pypi.org/p/yt-astro-analysis
     permissions:
       id-token: write


### PR DESCRIPTION
This replaces the need to use a token to upload to Pypi. Instead, one configures the project on Pypi to accept authentication from GitHub (https://pypi.org/manage/project/yt-astro-analysis/settings/publishing/).

This should allow us to completely remove the need for authorization tokens in the secrets.