### PR TITLE
DEP: unpin numpy (declare numpy 2.0 compatibility)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   rev: v0.3.4
   hooks:
   - id: ruff
-    args: [--fix]
+    args: [--fix, --show-fixes]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools>=61.2",
   "Cython>=3.0",
-  "numpy>=1.25, <2.0",
+  "numpy>=2.0.0",
 ]
 
 [project]
@@ -39,8 +39,7 @@ requires-python = ">=3.9"
 dependencies = [
     "h5py>=3.1.0",
     "yt>=4.0.1",
-    # upper cap should be lifted when build-time requirement is bumped to >=2.0, see
-    "numpy>=1.19.3, <2.0",
+    "numpy>=1.19.3, <3",
     "packaging>=20.9",
 ]
 
@@ -80,7 +79,11 @@ exclude = '''
 
 [tool.ruff.lint]
 exclude = ["*__init__.py", "*api.py"]
-ignore = ["E501"]
+ignore = [
+  "E501",
+  "NPY002", # numpy-legacy-random (not actually deprecated, and not auto-fixable)
+]
+
 select = [
     "E",
     "F",
@@ -91,6 +94,7 @@ select = [
     "YTT", # flake8-2020
     "I",   # isort
     "UP",  # pyupgrade
+    "NPY", # NumPy-specific rules
 ]
 
 [tool.ruff.lint.isort]

--- a/yt_astro_analysis/halo_analysis/halo_finding/halo_objects.py
+++ b/yt_astro_analysis/halo_analysis/halo_finding/halo_objects.py
@@ -112,7 +112,7 @@ class Halo:
         self._ds_sort = sp_pid.argsort()
         sp_pid = sp_pid[self._ds_sort]
         # This matches them up.
-        self._particle_mask = np.in1d(sp_pid, pid)
+        self._particle_mask = np.isin(sp_pid, pid)
         return self._particle_mask
 
     def center_of_mass(self):


### PR DESCRIPTION
I couldn't resist when I saw https://github.com/conda-forge/yt_astro_analysis-feedstock/pull/24

I haven't thoroughly checked this locally so I'm mostly just crossing fingers 🤞🏻 