### PR TITLE
Remove token to upload to Pypi

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -100,6 +100,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
This removes the `token` way of uploading to Pypi, which isn't necessary anymore (and even deprecated).