### PR TITLE
Next development version

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -28,18 +28,18 @@ BbTeX entries are provided below:
                     Cameron Hummels and
                     Andrew Myers and
                     Kacper Kowalik and
+                    Corentin Cadiou and
                     eganhila and
                     Sam Skillman and
                     Michael S. Warren and
-                    Corentin Cadiou and
-                    gsiisg and
                     John Wise and
+                    gsiisg and
                     madcpf and
                     Sam Leitner and
                     Anthony Scopatz and
                     Miguel de Val-Borro and
                     Casey W. Stark and
-                    Meng-Yuan, Ho and
+                    Ho, Meng-Yuan and
                     Ben Keller and
                     Bili Dong and
                     Mark Richardson and
@@ -47,15 +47,15 @@ BbTeX entries are provided below:
                     Nathan Goldbaum and
                     Sriram Sankar and
                     stonnes},
-    title        = {yt-project/yt\_astro\_analysis:
-                     yt\_astro\_analysis-1.1.3
+    title        = {yt-project/yt\_astro\_analysis: yt\_astro\_analysis
+                     1.1.4 Release
                     },
-    month        = oct,
-    year         = 2023,
+    month        = sep,
+    year         = 2025,
     publisher    = {Zenodo},
-    version      = {yt\_astro\_analysis-1.1.3},
-    doi          = {10.5281/zenodo.8431185},
-    url          = {https://doi.org/10.5281/zenodo.8431185},
+    version      = {yt\_astro\_analysis-1.1.4},
+    doi          = {10.5281/zenodo.17106789},
+    url          = {https://doi.org/10.5281/zenodo.17106789},
   }
 
   @ARTICLE{yt,

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![PyPI version](https://badge.fury.io/py/yt-astro-analysis.svg)](https://badge.fury.io/py/yt-astro-analysis)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/yt-astro-analysis/badges/version.svg)](https://anaconda.org/conda-forge/yt-astro-analysis)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1458961.svg)](https://doi.org/10.5281/zenodo.1458961)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1458960.svg)](https://doi.org/10.5281/zenodo.1458960)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 [![CircleCI](https://circleci.com/gh/yt-project/yt_astro_analysis.svg?style=svg)](https://circleci.com/gh/yt-project/yt_astro_analysis)

--- a/yt_astro_analysis/__init__.py
+++ b/yt_astro_analysis/__init__.py
@@ -13,7 +13,7 @@ API for yt astro analysis.
 # The full license is in the file COPYING.txt, distributed with this software.
 # -----------------------------------------------------------------------------
 
-__version__ = "1.1.4"
+__version__ = "1.2.dev4"
 
 from yt_astro_analysis import (
     cosmological_observation,


### PR DESCRIPTION
This updates to the next development version, the citation information to the latest release, and the zenodo badge. The badge now points to the general citation and will now update automatically.